### PR TITLE
Fixes for clang-tidy

### DIFF
--- a/src/dsmr/fields.cpp
+++ b/src/dsmr/fields.cpp
@@ -54,280 +54,214 @@ constexpr char units::kvar[];
 constexpr char units::kvarh[];
 
 constexpr ObisId identification::id;
-constexpr char identification::name_progmem[];
-constexpr const __FlashStringHelper *identification::name;
+constexpr char identification::name[];
 
 constexpr ObisId p1_version::id;
-constexpr char p1_version::name_progmem[];
-constexpr const __FlashStringHelper *p1_version::name;
+constexpr char p1_version::name[];
 
 /* extra field for Belgium */
 constexpr ObisId p1_version_be::id;
-constexpr char p1_version_be::name_progmem[];
-constexpr const __FlashStringHelper *p1_version_be::name;
+constexpr char p1_version_be::name[];
 
 constexpr ObisId timestamp::id;
-constexpr char timestamp::name_progmem[];
-constexpr const __FlashStringHelper *timestamp::name;
+constexpr char timestamp::name[];
 
 constexpr ObisId equipment_id::id;
-constexpr char equipment_id::name_progmem[];
-constexpr const __FlashStringHelper *equipment_id::name;
+constexpr char equipment_id::name[];
 
 /* extra for Lux */
 constexpr ObisId energy_delivered_lux::id;
-constexpr char energy_delivered_lux::name_progmem[];
-constexpr const __FlashStringHelper *energy_delivered_lux::name;
+constexpr char energy_delivered_lux::name[];
 
 constexpr ObisId energy_delivered_tariff1::id;
-constexpr char energy_delivered_tariff1::name_progmem[];
-constexpr const __FlashStringHelper *energy_delivered_tariff1::name;
+constexpr char energy_delivered_tariff1::name[];
 
 constexpr ObisId energy_delivered_tariff2::id;
-constexpr char energy_delivered_tariff2::name_progmem[];
-constexpr const __FlashStringHelper *energy_delivered_tariff2::name;
+constexpr char energy_delivered_tariff2::name[];
 
 /* extra for Lux */
 constexpr ObisId energy_returned_lux::id;
-constexpr char energy_returned_lux::name_progmem[];
-constexpr const __FlashStringHelper *energy_returned_lux::name;
+constexpr char energy_returned_lux::name[];
 
 constexpr ObisId energy_returned_tariff1::id;
-constexpr char energy_returned_tariff1::name_progmem[];
-constexpr const __FlashStringHelper *energy_returned_tariff1::name;
+constexpr char energy_returned_tariff1::name[];
 
 constexpr ObisId energy_returned_tariff2::id;
-constexpr char energy_returned_tariff2::name_progmem[];
-constexpr const __FlashStringHelper *energy_returned_tariff2::name;
+constexpr char energy_returned_tariff2::name[];
 
 /* extra for Lux */
 constexpr ObisId total_imported_energy::id;
-constexpr char total_imported_energy::name_progmem[];
-constexpr const __FlashStringHelper *total_imported_energy::name;
+constexpr char total_imported_energy::name[];
 
 /* extra for Lux */
 constexpr ObisId total_exported_energy::id;
-constexpr char total_exported_energy::name_progmem[];
-constexpr const __FlashStringHelper *total_exported_energy::name;
+constexpr char total_exported_energy::name[];
 
 /* extra for Lux */
 constexpr ObisId reactive_power_delivered::id;
-constexpr char reactive_power_delivered::name_progmem[];
-constexpr const __FlashStringHelper *reactive_power_delivered::name;
+constexpr char reactive_power_delivered::name[];
 
 /* extra for Lux */
 constexpr ObisId reactive_power_returned::id;
-constexpr char reactive_power_returned::name_progmem[];
-constexpr const __FlashStringHelper *reactive_power_returned::name;
+constexpr char reactive_power_returned::name[];
 
 constexpr ObisId electricity_tariff::id;
-constexpr char electricity_tariff::name_progmem[];
-constexpr const __FlashStringHelper *electricity_tariff::name;
+constexpr char electricity_tariff::name[];
 
 constexpr ObisId power_delivered::id;
-constexpr char power_delivered::name_progmem[];
-constexpr const __FlashStringHelper *power_delivered::name;
+constexpr char power_delivered::name[];
 
 constexpr ObisId power_returned::id;
-constexpr char power_returned::name_progmem[];
-constexpr const __FlashStringHelper *power_returned::name;
+constexpr char power_returned::name[];
 
 constexpr ObisId electricity_threshold::id;
-constexpr char electricity_threshold::name_progmem[];
-constexpr const __FlashStringHelper *electricity_threshold::name;
+constexpr char electricity_threshold::name[];
 
 constexpr ObisId electricity_switch_position::id;
-constexpr char electricity_switch_position::name_progmem[];
-constexpr const __FlashStringHelper *electricity_switch_position::name;
+constexpr char electricity_switch_position::name[];
 
 constexpr ObisId electricity_failures::id;
-constexpr char electricity_failures::name_progmem[];
-constexpr const __FlashStringHelper *electricity_failures::name;
+constexpr char electricity_failures::name[];
 
 constexpr ObisId electricity_long_failures::id;
-constexpr char electricity_long_failures::name_progmem[];
-constexpr const __FlashStringHelper *electricity_long_failures::name;
+constexpr char electricity_long_failures::name[];
 
 constexpr ObisId electricity_failure_log::id;
-constexpr char electricity_failure_log::name_progmem[];
-constexpr const __FlashStringHelper *electricity_failure_log::name;
+constexpr char electricity_failure_log::name[];
 
 constexpr ObisId electricity_sags_l1::id;
-constexpr char electricity_sags_l1::name_progmem[];
-constexpr const __FlashStringHelper *electricity_sags_l1::name;
+constexpr char electricity_sags_l1::name[];
 
 constexpr ObisId electricity_sags_l2::id;
-constexpr char electricity_sags_l2::name_progmem[];
-constexpr const __FlashStringHelper *electricity_sags_l2::name;
+constexpr char electricity_sags_l2::name[];
 
 constexpr ObisId electricity_sags_l3::id;
-constexpr char electricity_sags_l3::name_progmem[];
-constexpr const __FlashStringHelper *electricity_sags_l3::name;
+constexpr char electricity_sags_l3::name[];
 
 constexpr ObisId electricity_swells_l1::id;
-constexpr char electricity_swells_l1::name_progmem[];
-constexpr const __FlashStringHelper *electricity_swells_l1::name;
+constexpr char electricity_swells_l1::name[];
 
 constexpr ObisId electricity_swells_l2::id;
-constexpr char electricity_swells_l2::name_progmem[];
-constexpr const __FlashStringHelper *electricity_swells_l2::name;
+constexpr char electricity_swells_l2::name[];
 
 constexpr ObisId electricity_swells_l3::id;
-constexpr char electricity_swells_l3::name_progmem[];
-constexpr const __FlashStringHelper *electricity_swells_l3::name;
+constexpr char electricity_swells_l3::name[];
 
 constexpr ObisId message_short::id;
-constexpr char message_short::name_progmem[];
-constexpr const __FlashStringHelper *message_short::name;
+constexpr char message_short::name[];
 
 constexpr ObisId message_long::id;
-constexpr char message_long::name_progmem[];
-constexpr const __FlashStringHelper *message_long::name;
+constexpr char message_long::name[];
 
 constexpr ObisId voltage_l1::id;
-constexpr char voltage_l1::name_progmem[];
-constexpr const __FlashStringHelper *voltage_l1::name;
+constexpr char voltage_l1::name[];
 
 constexpr ObisId voltage_l2::id;
-constexpr char voltage_l2::name_progmem[];
-constexpr const __FlashStringHelper *voltage_l2::name;
+constexpr char voltage_l2::name[];
 
 constexpr ObisId voltage_l3::id;
-constexpr char voltage_l3::name_progmem[];
-constexpr const __FlashStringHelper *voltage_l3::name;
+constexpr char voltage_l3::name[];
 
 constexpr ObisId current_l1::id;
-constexpr char current_l1::name_progmem[];
-constexpr const __FlashStringHelper *current_l1::name;
+constexpr char current_l1::name[];
 
 constexpr ObisId current_l2::id;
-constexpr char current_l2::name_progmem[];
-constexpr const __FlashStringHelper *current_l2::name;
+constexpr char current_l2::name[];
 
 constexpr ObisId current_l3::id;
-constexpr char current_l3::name_progmem[];
-constexpr const __FlashStringHelper *current_l3::name;
+constexpr char current_l3::name[];
 
 constexpr ObisId power_delivered_l1::id;
-constexpr char power_delivered_l1::name_progmem[];
-constexpr const __FlashStringHelper *power_delivered_l1::name;
+constexpr char power_delivered_l1::name[];
 
 constexpr ObisId power_delivered_l2::id;
-constexpr char power_delivered_l2::name_progmem[];
-constexpr const __FlashStringHelper *power_delivered_l2::name;
+constexpr char power_delivered_l2::name[];
 
 constexpr ObisId power_delivered_l3::id;
-constexpr char power_delivered_l3::name_progmem[];
-constexpr const __FlashStringHelper *power_delivered_l3::name;
+constexpr char power_delivered_l3::name[];
 
 constexpr ObisId power_returned_l1::id;
-constexpr char power_returned_l1::name_progmem[];
-constexpr const __FlashStringHelper *power_returned_l1::name;
+constexpr char power_returned_l1::name[];
 
 constexpr ObisId power_returned_l2::id;
-constexpr char power_returned_l2::name_progmem[];
-constexpr const __FlashStringHelper *power_returned_l2::name;
+constexpr char power_returned_l2::name[];
 
 constexpr ObisId power_returned_l3::id;
-constexpr char power_returned_l3::name_progmem[];
-constexpr const __FlashStringHelper *power_returned_l3::name;
+constexpr char power_returned_l3::name[];
 
 /* LUX */
 constexpr ObisId reactive_power_delivered_l1::id;
-constexpr char reactive_power_delivered_l1::name_progmem[];
-constexpr const __FlashStringHelper *reactive_power_delivered_l1::name;
+constexpr char reactive_power_delivered_l1::name[];
 
 /* LUX */
 constexpr ObisId reactive_power_delivered_l2::id;
-constexpr char reactive_power_delivered_l2::name_progmem[];
-constexpr const __FlashStringHelper *reactive_power_delivered_l2::name;
+constexpr char reactive_power_delivered_l2::name[];
 
 /* LUX */
 constexpr ObisId reactive_power_delivered_l3::id;
-constexpr char reactive_power_delivered_l3::name_progmem[];
-constexpr const __FlashStringHelper *reactive_power_delivered_l3::name;
+constexpr char reactive_power_delivered_l3::name[];
 
 /* LUX */
 constexpr ObisId reactive_power_returned_l1::id;
-constexpr char reactive_power_returned_l1::name_progmem[];
-constexpr const __FlashStringHelper *reactive_power_returned_l1::name;
+constexpr char reactive_power_returned_l1::name[];
 
 /* LUX */
 constexpr ObisId reactive_power_returned_l2::id;
-constexpr char reactive_power_returned_l2::name_progmem[];
-constexpr const __FlashStringHelper *reactive_power_returned_l2::name;
+constexpr char reactive_power_returned_l2::name[];
 
 /* LUX */
 constexpr ObisId reactive_power_returned_l3::id;
-constexpr char reactive_power_returned_l3::name_progmem[];
-constexpr const __FlashStringHelper *reactive_power_returned_l3::name;
+constexpr char reactive_power_returned_l3::name[];
 
 constexpr ObisId gas_device_type::id;
-constexpr char gas_device_type::name_progmem[];
-constexpr const __FlashStringHelper *gas_device_type::name;
+constexpr char gas_device_type::name[];
 
 constexpr ObisId gas_equipment_id::id;
-constexpr char gas_equipment_id::name_progmem[];
-constexpr const __FlashStringHelper *gas_equipment_id::name;
+constexpr char gas_equipment_id::name[];
 
 constexpr ObisId gas_valve_position::id;
-constexpr char gas_valve_position::name_progmem[];
-constexpr const __FlashStringHelper *gas_valve_position::name;
+constexpr char gas_valve_position::name[];
 
 /* _NL */
 constexpr ObisId gas_delivered::id;
-constexpr char gas_delivered::name_progmem[];
-constexpr const __FlashStringHelper *gas_delivered::name;
+constexpr char gas_delivered::name[];
 
 /* _BE */
 constexpr ObisId gas_delivered_be::id;
-constexpr char gas_delivered_be::name_progmem[];
-constexpr const __FlashStringHelper *gas_delivered_be::name;
+constexpr char gas_delivered_be::name[];
 
 constexpr ObisId thermal_device_type::id;
-constexpr char thermal_device_type::name_progmem[];
-constexpr const __FlashStringHelper *thermal_device_type::name;
+constexpr char thermal_device_type::name[];
 
 constexpr ObisId thermal_equipment_id::id;
-constexpr char thermal_equipment_id::name_progmem[];
-constexpr const __FlashStringHelper *thermal_equipment_id::name;
+constexpr char thermal_equipment_id::name[];
 
 constexpr ObisId thermal_valve_position::id;
-constexpr char thermal_valve_position::name_progmem[];
-constexpr const __FlashStringHelper *thermal_valve_position::name;
+constexpr char thermal_valve_position::name[];
 
 constexpr ObisId thermal_delivered::id;
-constexpr char thermal_delivered::name_progmem[];
-constexpr const __FlashStringHelper *thermal_delivered::name;
+constexpr char thermal_delivered::name[];
 
 constexpr ObisId water_device_type::id;
-constexpr char water_device_type::name_progmem[];
-constexpr const __FlashStringHelper *water_device_type::name;
+constexpr char water_device_type::name[];
 
 constexpr ObisId water_equipment_id::id;
-constexpr char water_equipment_id::name_progmem[];
-constexpr const __FlashStringHelper *water_equipment_id::name;
+constexpr char water_equipment_id::name[];
 
 constexpr ObisId water_valve_position::id;
-constexpr char water_valve_position::name_progmem[];
-constexpr const __FlashStringHelper *water_valve_position::name;
+constexpr char water_valve_position::name[];
 
 constexpr ObisId water_delivered::id;
-constexpr char water_delivered::name_progmem[];
-constexpr const __FlashStringHelper *water_delivered::name;
+constexpr char water_delivered::name[];
 
 constexpr ObisId sub_device_type::id;
-constexpr char sub_device_type::name_progmem[];
-constexpr const __FlashStringHelper *sub_device_type::name;
+constexpr char sub_device_type::name[];
 
 constexpr ObisId sub_equipment_id::id;
-constexpr char sub_equipment_id::name_progmem[];
-constexpr const __FlashStringHelper *sub_equipment_id::name;
+constexpr char sub_equipment_id::name[];
 
 constexpr ObisId sub_valve_position::id;
-constexpr char sub_valve_position::name_progmem[];
-constexpr const __FlashStringHelper *sub_valve_position::name;
+constexpr char sub_valve_position::name[];
 
 constexpr ObisId sub_delivered::id;
-constexpr char sub_delivered::name_progmem[];
-constexpr const __FlashStringHelper *sub_delivered::name;
+constexpr char sub_delivered::name[];

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -199,8 +199,7 @@ namespace dsmr
     value_t fieldname;                                                                                               \
     bool fieldname##_present = false;                                                                                \
     static constexpr ObisId id = obis;                                                                               \
-    static constexpr char name_progmem[] DSMR_PROGMEM = #fieldname;                                                  \
-    static constexpr const __FlashStringHelper *name = reinterpret_cast<const __FlashStringHelper *>(&name_progmem); \
+    static constexpr char name[] = #fieldname;                                                                         \
     value_t &val() { return fieldname; }                                                                             \
     bool &present() { return fieldname##_present; }                                                                  \
   }

--- a/src/dsmr/util.h
+++ b/src/dsmr/util.h
@@ -30,12 +30,6 @@
 
 #pragma once
 
-#ifdef ARDUINO_ARCH_ESP8266
-#define DSMR_PROGMEM
-#else
-#define DSMR_PROGMEM PROGMEM
-#endif
-
 #include <Arduino.h>
 
 namespace dsmr
@@ -120,10 +114,10 @@ namespace dsmr
   struct ParseResult : public _ParseResult<ParseResult<T>, T>
   {
     const char *next = NULL;
-    const __FlashStringHelper *err = NULL;
+    const char *err = NULL;
     const char *ctx = NULL;
 
-    ParseResult &fail(const __FlashStringHelper *err, const char *ctx = NULL)
+    ParseResult &fail(const char *err, const char *ctx = NULL)
     {
       this->err = err;
       this->ctx = ctx;


### PR DESCRIPTION
Mainly removes all `PROGMEM` stuff. Reasons:
- Breaks clang-tidy checks for esphome, and didn't want to investigate too much.
- These are relatively few string constants, and pretty short too - compared to what we have in ESPHome this shouldn't be an issue
- Due to no longer using `F()`, the compiler can now more easily dedup string constants, which is important for the templated functions.