### PR TITLE
Change stringfield BE p1 version to 5 long

### DIFF
--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -210,7 +210,7 @@ namespace dsmr
 
     /* Version information for P1 output */
     DEFINE_FIELD(p1_version, String, ObisId(1, 3, 0, 2, 8), StringField, 2, 2);
-    DEFINE_FIELD(p1_version_be, String, ObisId(0, 0, 96, 1, 4), StringField, 2, 2);
+    DEFINE_FIELD(p1_version_be, String, ObisId(0, 0, 96, 1, 4), StringField, 5, 5);
 
     /* Date-time stamp of the P1 message */
     DEFINE_FIELD(timestamp, String, ObisId(0, 0, 1, 0, 0), TimestampField);


### PR DESCRIPTION
Suggestion to resolve parsing error of BE obisid 96.1.4 with value "50125"

https://github.com/esphome/issues/issues/2340