### PR TITLE
Work-around for meters that publish W instead of kW

### DIFF
--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -102,7 +102,7 @@ namespace dsmr
   // digits. To prevent inefficient floating point operations, we store
   // them as a fixed-point number: an integer that stores the value in
   // thousands. For example, a value of 1.234 kWh is stored as 1234. This
-  // effectively means that the integer value is het value in Wh. To allow
+  // effectively means that the integer value is the value in Wh. To allow
   // automatic printing of these values, both the original unit and the
   // integer unit is passed as a template argument.
   template <typename T, const char *_unit, const char *_int_unit>
@@ -117,9 +117,9 @@ namespace dsmr
         return res_float;
       }
       // If not, then check for an int value, plus its expected unit type.
-      // This accomodates for some smart meters that publish int values intead
-      // of floats. E.g. most meters might publish "1-0:1.8.0(000441.879*kWh)",
-      // but there are meters that use "1-0:1.8.0(000441879*Wh)" instead.
+      // This accomodates for some smart meters that publish int values instead
+      // of floats. E.g. most meters would publish "1-0:1.8.0(000441.879*kWh)",
+      // but some use "1-0:1.8.0(000441879*Wh)" instead.
       ParseResult<uint32_t> res_int = NumParser::parse(0, _int_unit, str, end);
       if (!res_int.err) {
         static_cast<T *>(this)->val()._value = res_int.result;

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -121,8 +121,11 @@ namespace dsmr
       // of floats. E.g. most meters might publish "1-0:1.8.0(000441.879*kWh)",
       // but there are meters that use "1-0:1.8.0(000441879*Wh)" instead.
       ParseResult<uint32_t> res_int = NumParser::parse(0, _int_unit, str, end);
-      if (!res_int.err)
-        static_cast<T *>(this)->val()._value = res_float.result;
+      if (!res_int.err) {
+        static_cast<T *>(this)->val()._value = res_int.result;
+        return res_int;
+      }
+      // If not, then return the initial error result for the float parsing step.
       return res_float;
     }
 


### PR DESCRIPTION
## The issue

While specifications tell us that a smart meter ought to publish its values as floating point values in kW, there are meters out there that publish an integer value in W. This results in error messages like these:

```
Invalid unit
[E][dsmr:138]: 1-0:1.8.0(000441874*Wh)
```

## The solution

This PR modifies the parser, to allow both a float and an integer, as long as the unit as published by the meter matches those types. So based on the example from above, meters can now publish either of:

* `1-0:1.8.0(000441874*Wh)`
* `1-0:1.8.0(00044.1874*kWh)

Any other combination of data type and unit will still result in an `Invalid unit`, meaning that these two are not accepted by the parser:

* `1-0:1.8.0(000441874*kWh)`
* `1-0:1.8.0(00044.1874*Wh)`

The solution is backward compatible, and the change has been tested against a standard smart meter and an affected smart meter (a Sagemom smart meter from Austria).