### PR TITLE
Bump library version to 0.6

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "Dsmr",
-  "version": "0.5",
+  "version": "0.6",
   "description": "Parser and utilities for Dutch Smart Meters (Implementing DSMR)",
   "keywords": "dsmr",
   "repository": {


### PR DESCRIPTION
Bump the library version, so we can do a new release that can be used by PlatformIO.