### PR TITLE
Use regex for identification chack. Add Warmtelink allowed identification.

### DIFF
--- a/examples/warmtelink/warmtelink_parse.ino
+++ b/examples/warmtelink/warmtelink_parse.ino
@@ -1,0 +1,64 @@
+/*
+ * Permission is hereby granted, free of charge, to anyone
+ * obtaining a copy of this document and accompanying files,
+ * to do whatever they want with them without any restriction,
+ * including, but not limited to, copying, modification and redistribution.
+ * NO WARRANTY OF ANY KIND IS PROVIDED.
+ *
+ * Example that shows how to parse a P1 message and automatically print
+ * the result.
+*/
+
+#include "dsmr.h"
+
+// Data to parse
+const char msg[] =
+  "/NWB-WARMTELINK\r\n"
+  "\r\n"
+  "1-3:0.2.8(50)\r\n"
+  "0-0:1.0.0(220208231051W)\r\n"
+  "0-0:96.1.1(ADB3100000043021)\r\n"
+  "0-0:96.13.1()\r\n"
+  "0-0:96.13.0()\r\n"
+  "0-1:24.1.0(004)\r\n"
+  "0-1:96.1.0(717285092D2C340C)\r\n"
+  "0-1:24.2.1(220208231051W)(46.720*GJ)\r\n"
+  "!4FAC\r\n";
+
+/**
+ * Define the data we're interested in, as well as the datastructure to
+ * hold the parsed data.
+ * Each template argument below results in a field of the same name.
+ */
+using MyData = ParsedData<
+  /* String */ identification,
+  /* String */ p1_version,
+  /* String */ timestamp,
+  /* String */ equipment_id,
+  /* String */ message_short,
+  /* String */ message_long,
+  /* uint16_t */ thermal_device_type,
+  /* String */ thermal_equipment_id,
+  /* FixedValue */ thermal_delivered
+>;
+
+void setup() {
+  Serial.begin(115200);
+
+  MyData data;
+  ParseResult<void> res = P1Parser::parse(&data, msg, lengthof(msg));
+  if (res.err) {
+    // Parsing error, show it
+    Serial.println(res.fullError(msg, msg + lengthof(msg)));
+  } else if (!data.all_present()) {
+    Serial.println("Some fields are missing");
+  } else {
+    // Succesfully parsed, print results:
+    Serial.println(data.identification);
+    Serial.print(data.thermal_delivered.int_val());
+    Serial.println("GJ");
+  }
+}
+
+void loop () {
+}

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "Dsmr",
-  "version": "0.6",
+  "version": "0.7",
   "description": "Parser and utilities for Dutch Smart Meters (Implementing DSMR)",
   "keywords": "dsmr",
   "repository": {

--- a/src/dsmr/parser.h
+++ b/src/dsmr/parser.h
@@ -32,6 +32,25 @@
 
 #include "crc16.h"
 #include "util.h"
+#include "regex.h"
+
+/** The first identification line looks like:
+* XXX5<id string>
+* The DSMR spec is vague on details, but in 62056-21, the X's
+* are a three-leter (registerd) manufacturer ID, the id
+* string is up to 16 chars of arbitrary characters and the
+* '5' is a baud rate indication. 5 apparently means 9600,
+* which DSMR 3.x and below used. It seems that DSMR 2.x
+* passed '3' here (which is mandatory for "mode D"
+* communication according to 62956-21), so we also allow
+* that.
+* The 'WARMTELINK' is added to support vattenfall warmtelink.
+* See: https://www.vattenfall.nl/producten/stadsverwarming/warmtelink/
+* The identification like for the device looks like: "NWB-WARMTELINK" 
+*/
+#ifndef DSMR_IDENTIFICATION_REGEX
+#define DSMR_IDENTIFICATION_REGEX "...[3,5].*|.*-WARMTELINK"
+#endif
 
 namespace dsmr
 {
@@ -395,18 +414,13 @@ namespace dsmr
       {
         if (*line_end == '\r' || *line_end == '\n')
         {
-          // The first identification line looks like:
-          // XXX5<id string>
-          // The DSMR spec is vague on details, but in 62056-21, the X's
-          // are a three-leter (registerd) manufacturer ID, the id
-          // string is up to 16 chars of arbitrary characters and the
-          // '5' is a baud rate indication. 5 apparently means 9600,
-          // which DSMR 3.x and below used. It seems that DSMR 2.x
-          // passed '3' here (which is mandatory for "mode D"
-          // communication according to 62956-21), so we also allow
-          // that.
-          if (line_start + 3 >= line_end || (line_start[3] != '5' && line_start[3] != '3'))
+          regex_t regex;
+          int return_value;
+          return_value = regcomp(&regex, DSMR_IDENTIFICATION_REGEX, REG_EXTENDED);
+          return_value = regexec(&regex, line_start, 0, NULL, 0);
+          if (return_value != 0)
             return res.fail("Invalid identification string", line_start);
+          regfree(&regex);
           // Offer it for processing using the all-ones Obis ID, which
           // is not otherwise valid.
           ParseResult<void> tmp = data->parse_line(ObisId(255, 255, 255, 255, 255, 255), line_start, line_end);


### PR DESCRIPTION
[Warmtelink](https://www.vattenfall.nl/producten/stadsverwarming/warmtelink/) has slightly different identification, like: NWB-WARMTELINK.
To make it bit more flexible, regexp match is used from definition (DSMR_IDENTIFICATION_REGEX).
