### PR TITLE
Add support for Belgian Cappacity Tarif regarding eMUCs – P1 V1.7.1

### DIFF
--- a/src/dsmr/fields.cpp
+++ b/src/dsmr/fields.cpp
@@ -269,11 +269,8 @@ constexpr char sub_valve_position::name[];
 constexpr ObisId sub_delivered::id;
 constexpr char sub_delivered::name[];
 
-constexpr ObisId quart_hourly_current_average_peak_consumption::id;
-constexpr char quart_hourly_current_average_peak_consumption::name[];
+constexpr ObisId active_energy_import_current_average_demand::id;
+constexpr char active_energy_import_current_average_demand::name[];
 
-constexpr ObisId quart_hourly_max_peak_this_month::id;
-constexpr char quart_hourly_max_peak_this_month::name[];
-
-constexpr ObisId quart_hourly_average_peak_last_13months::id;
-constexpr char quart_hourly_average_peak_last_13months::name[];
+constexpr ObisId active_energy_import_maximum_demand_running_month::id;
+constexpr char active_energy_import_maximum_demand_running_month::name[];

--- a/src/dsmr/fields.cpp
+++ b/src/dsmr/fields.cpp
@@ -268,3 +268,12 @@ constexpr char sub_valve_position::name[];
 
 constexpr ObisId sub_delivered::id;
 constexpr char sub_delivered::name[];
+
+constexpr ObisId quart_hourly_current_average_peak_consumption::id;
+constexpr char quart_hourly_current_average_peak_consumption::name[];
+
+constexpr ObisId quart_hourly_max_peak_this_month::id;
+constexpr char quart_hourly_max_peak_this_month::name[];
+
+constexpr ObisId quart_hourly_average_peak_last_13months::id;
+constexpr char quart_hourly_average_peak_last_13months::name[];

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -430,13 +430,12 @@ namespace dsmr
  * E meter) (Note: 4.x spec has "hourly meter reading") */
     DEFINE_FIELD(sub_delivered, TimestampedFixedValue, ObisId(0, SUB_MBUS_ID, 24, 2, 1), TimestampedFixedField,
                  units::m3, units::dm3);
-    /*
-    * Extra fields used for Belgian capacity rate/peak consumption (cappaciteitstarief)
-    */
-    /*Current rolling avg of the last 15 minutes*/
+
+    /* Extra fields used for Belgian capacity rate/peak consumption (cappaciteitstarief) */
+    /*Current quart-hourly energy consumption*/
     DEFINE_FIELD(active_energy_import_current_average_demand, FixedValue, ObisId(1, 0, 1, 4, 0), FixedField, units::kW, units::W);
-    /*Current rolling avg of the last 15 minutes*/
-    DEFINE_FIELD(active_energy_import_maximum_demand_running_month, FixedValue, ObisId(1, 0, 1, 6, 0), FixedField, units::kW, units::W);
+    /*Maximum energy consumption from the current month*/
+    DEFINE_FIELD(active_energy_import_maximum_demand_running_month, TimestampedFixedValue, ObisId(1, 0, 1, 6, 0), TimestampedFixedField, units::kW, units::W);
 
   } // namespace fields
 

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -434,12 +434,9 @@ namespace dsmr
     * Extra fields used for Belgian capacity rate/peak consumption (cappaciteitstarief)
     */
     /*Current rolling avg of the last 15 minutes*/
-    DEFINE_FIELD(quart_hourly_current_average_peak_consumption, FixedValue, ObisId(1, 0, 1, 4, 0), FixedField, units::kW, units::W);
+    DEFINE_FIELD(active_energy_import_current_average_demand, FixedValue, ObisId(1, 0, 1, 4, 0), FixedField, units::kW, units::W);
     /*Current rolling avg of the last 15 minutes*/
-    DEFINE_FIELD(quart_hourly_max_peak_this_month, FixedValue, ObisId(1, 0, 1, 6, 0), FixedField, units::kW, units::W);
-    /*Current Monthly max consumption*/
-    DEFINE_FIELD(quart_hourly_peak_consumption_last_13months, FixedValue, ObisId(0, 0, 98, 1, 0), FixedField, units::kW, units::W);
-
+    DEFINE_FIELD(active_energy_import_maximum_demand_running_month, FixedValue, ObisId(1, 0, 1, 6, 0), FixedField, units::kW, units::W);
 
   } // namespace fields
 

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -430,6 +430,16 @@ namespace dsmr
  * E meter) (Note: 4.x spec has "hourly meter reading") */
     DEFINE_FIELD(sub_delivered, TimestampedFixedValue, ObisId(0, SUB_MBUS_ID, 24, 2, 1), TimestampedFixedField,
                  units::m3, units::dm3);
+    /*
+    * Extra fields used for Belgian capacity rate/peak consumption (cappaciteitstarief)
+    */
+    /*Current rolling avg of the last 15 minutes*/
+    DEFINE_FIELD(quart_hourly_current_average_peak_consumption, FixedValue, ObisId(1, 0, 1, 4, 0), FixedField, units::kW, units::W);
+    /*Current rolling avg of the last 15 minutes*/
+    DEFINE_FIELD(quart_hourly_max_peak_this_month, FixedValue, ObisId(1, 0, 1, 6, 0), FixedField, units::kW, units::W);
+    /*Current Monthly max consumption*/
+    DEFINE_FIELD(quart_hourly_peak_consumption_last_13months, FixedValue, ObisId(0, 0, 98, 1, 0), FixedField, units::kW, units::W);
+
 
   } // namespace fields
 


### PR DESCRIPTION
Following The documentation at [maakjemeterslim.be](https://maakjemeterslim.be/aanbieder)  (e-MUCS_P1_Ed_1_7_1.pdf)  i added and tested the addition of the folowing codes:
 - Current average demand - Active energy import, (1-0:1.4.0)
 - Maximum demand – Active energy import of the running month, (1-0:1.6.0)
 
 I did not add:
  - Maximum demand – Active energy import of the last 13 months, (0-0:98.1.0)
  
 As it seems to be a tripple timestamp+value (man,max,avg?) string and am unable to find if this can be parsed at this point.
 Example (0-0:98.1.0(3)(1-0:1.6.0)(1-0:1.6.0)(200501000000S)(200423192538S)(03.695*kW)(200401000000S)(200305122139S)05.980*kW)(200301000000S)(200210035421W)(04.318*kW))