### PR TITLE
Add field 0-0:98.1.0 again as StringField

### DIFF
--- a/src/dsmr/fields.cpp
+++ b/src/dsmr/fields.cpp
@@ -274,3 +274,6 @@ constexpr char active_energy_import_current_average_demand::name[];
 
 constexpr ObisId active_energy_import_maximum_demand_running_month::id;
 constexpr char active_energy_import_maximum_demand_running_month::name[];
+
+constexpr ObisId active_energy_import_maximum_demand_last_13_months::id;
+constexpr char active_energy_import_maximum_demand_last_13_months::name[];

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -437,7 +437,7 @@ namespace dsmr
     /*Maximum energy consumption from the current month*/
     DEFINE_FIELD(active_energy_import_maximum_demand_running_month, TimestampedFixedValue, ObisId(1, 0, 1, 6, 0), TimestampedFixedField, units::kW, units::W);
     /*Maximum energy consumption from the last 13 months*/
-    DEFINE_FIELD(active_energy_import_maximum_demand_last_13_months, String, ObisId(0, 0, 98, 1, 0), StringField, 0, 255);
+    DEFINE_FIELD(active_energy_import_maximum_demand_last_13_months, String, ObisId(0, 0, 98, 1, 0), RawField);
 
   } // namespace fields
 

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -436,6 +436,8 @@ namespace dsmr
     DEFINE_FIELD(active_energy_import_current_average_demand, FixedValue, ObisId(1, 0, 1, 4, 0), FixedField, units::kW, units::W);
     /*Maximum energy consumption from the current month*/
     DEFINE_FIELD(active_energy_import_maximum_demand_running_month, TimestampedFixedValue, ObisId(1, 0, 1, 6, 0), TimestampedFixedField, units::kW, units::W);
+    /*Maximum energy consumption from the last 13 months*/
+    DEFINE_FIELD(active_energy_import_maximum_demand_last_13_months, String, ObisId(0, 0, 98, 1, 0), StringField, 0, 255);
 
   } // namespace fields
 


### PR DESCRIPTION
I added the field 0-0:98.1.0*255 as a StringField. This way it can be parsed outside of this code.
(This is my first pull-request ever. 
I hope it is done in a correct way.)
