### PR TITLE
Addition OBIS values used in Lithuania smart meeters.

### DIFF
--- a/src/dsmr/fields.cpp
+++ b/src/dsmr/fields.cpp
@@ -325,8 +325,8 @@ constexpr char apparent_return_power_l3::name[];
 constexpr ObisId active_demand_power::id;
 constexpr char active_demand_power::name[];
 
-constexpr ObisId active_demand_net::id;
-constexpr char active_demand_net::name[];
+//constexpr ObisId active_demand_net::id;
+//constexpr char active_demand_net::name[];
 
 constexpr ObisId active_demand_abs::id;
 constexpr char active_demand_abs::name[];

--- a/src/dsmr/fields.cpp
+++ b/src/dsmr/fields.cpp
@@ -42,8 +42,10 @@ constexpr char units::kWh[];
 constexpr char units::Wh[];
 constexpr char units::kW[];
 constexpr char units::W[];
+constexpr char units::kV[];
 constexpr char units::V[];
 constexpr char units::mV[];
+constexpr char units::kA[];
 constexpr char units::A[];
 constexpr char units::mA[];
 constexpr char units::m3[];
@@ -52,6 +54,11 @@ constexpr char units::GJ[];
 constexpr char units::MJ[];
 constexpr char units::kvar[];
 constexpr char units::kvarh[];
+constexpr char units::kVA[];
+constexpr char units::VA[];
+constexpr char units::s[];
+constexpr char units::Hz[];
+constexpr char units::kHz[];
 
 constexpr ObisId identification::id;
 constexpr char identification::name[];
@@ -79,6 +86,24 @@ constexpr char energy_delivered_tariff1::name[];
 constexpr ObisId energy_delivered_tariff2::id;
 constexpr char energy_delivered_tariff2::name[];
 
+constexpr ObisId energy_delivered_tariff3::id;
+constexpr char energy_delivered_tariff3::name[];
+
+constexpr ObisId energy_delivered_tariff4::id;
+constexpr char energy_delivered_tariff4::name[];
+
+constexpr ObisId reactive_energy_delivered_tariff1::id;
+constexpr char reactive_energy_delivered_tariff1::name[];
+
+constexpr ObisId reactive_energy_delivered_tariff2::id;
+constexpr char reactive_energy_delivered_tariff2::name[];
+
+constexpr ObisId reactive_energy_delivered_tariff3::id;
+constexpr char reactive_energy_delivered_tariff3::name[];
+
+constexpr ObisId reactive_energy_delivered_tariff4::id;
+constexpr char reactive_energy_delivered_tariff4::name[];
+
 /* extra for Lux */
 constexpr ObisId energy_returned_lux::id;
 constexpr char energy_returned_lux::name[];
@@ -88,6 +113,24 @@ constexpr char energy_returned_tariff1::name[];
 
 constexpr ObisId energy_returned_tariff2::id;
 constexpr char energy_returned_tariff2::name[];
+
+constexpr ObisId energy_returned_tariff3::id;
+constexpr char energy_returned_tariff3::name[];
+
+constexpr ObisId energy_returned_tariff4::id;
+constexpr char energy_returned_tariff4::name[];
+
+constexpr ObisId reactive_energy_returned_tariff1::id;
+constexpr char reactive_energy_returned_tariff1::name[];
+
+constexpr ObisId reactive_energy_returned_tariff2::id;
+constexpr char reactive_energy_returned_tariff2::name[];
+
+constexpr ObisId reactive_energy_returned_tariff3::id;
+constexpr char reactive_energy_returned_tariff3::name[];
+
+constexpr ObisId reactive_energy_returned_tariff4::id;
+constexpr char reactive_energy_returned_tariff4::name[];
 
 /* extra for Lux */
 constexpr ObisId total_imported_energy::id;
@@ -138,6 +181,24 @@ constexpr char electricity_sags_l2::name[];
 constexpr ObisId electricity_sags_l3::id;
 constexpr char electricity_sags_l3::name[];
 
+constexpr ObisId voltage_sag_time_l1::id;
+constexpr char voltage_sag_time_l1::name[];
+
+constexpr ObisId voltage_sag_time_l2::id;
+constexpr char voltage_sag_time_l2::name[];
+
+constexpr ObisId voltage_sag_time_l3::id;
+constexpr char voltage_sag_time_l3::name[];
+
+constexpr ObisId voltage_sag_l1::id;
+constexpr char voltage_sag_l1::name[];
+
+constexpr ObisId voltage_sag_l2::id;
+constexpr char voltage_sag_l2::name[];
+
+constexpr ObisId voltage_sag_l3::id;
+constexpr char voltage_sag_l3::name[];
+
 constexpr ObisId electricity_swells_l1::id;
 constexpr char electricity_swells_l1::name[];
 
@@ -147,11 +208,32 @@ constexpr char electricity_swells_l2::name[];
 constexpr ObisId electricity_swells_l3::id;
 constexpr char electricity_swells_l3::name[];
 
+constexpr ObisId voltage_swell_time_l1::id;
+constexpr char voltage_swell_time_l1::name[];
+
+constexpr ObisId voltage_swell_time_l2::id;
+constexpr char voltage_swell_time_l2::name[];
+
+constexpr ObisId voltage_swell_time_l3::id;
+constexpr char voltage_swell_time_l3::name[];
+
+constexpr ObisId voltage_swell_l1::id;
+constexpr char voltage_swell_l1::name[];
+
+constexpr ObisId voltage_swell_l2::id;
+constexpr char voltage_swell_l2::name[];
+
+constexpr ObisId voltage_swell_l3::id;
+constexpr char voltage_swell_l3::name[];
+
 constexpr ObisId message_short::id;
 constexpr char message_short::name[];
 
 constexpr ObisId message_long::id;
 constexpr char message_long::name[];
+
+constexpr ObisId voltage::id;
+constexpr char voltage::name[];
 
 constexpr ObisId voltage_l1::id;
 constexpr char voltage_l1::name[];
@@ -162,6 +244,15 @@ constexpr char voltage_l2::name[];
 constexpr ObisId voltage_l3::id;
 constexpr char voltage_l3::name[];
 
+constexpr ObisId voltage_avg_l1::id;
+constexpr char voltage_avg_l1::name[];
+
+constexpr ObisId voltage_avg_l2::id;
+constexpr char voltage_avg_l2::name[];
+
+constexpr ObisId voltage_avg_l3::id;
+constexpr char voltage_avg_l3::name[];
+
 constexpr ObisId current_l1::id;
 constexpr char current_l1::name[];
 
@@ -170,6 +261,24 @@ constexpr char current_l2::name[];
 
 constexpr ObisId current_l3::id;
 constexpr char current_l3::name[];
+
+constexpr ObisId current_fuse_l1::id;
+constexpr char current_fuse_l1::name[];
+
+constexpr ObisId current_fuse_l2::id;
+constexpr char current_fuse_l2::name[];
+
+constexpr ObisId current_fuse_l3::id;
+constexpr char current_fuse_l3::name[];
+
+constexpr ObisId current::id;
+constexpr char current::name[];
+
+constexpr ObisId current_n::id;
+constexpr char current_n::name[];
+
+constexpr ObisId current_sum::id;
+constexpr char current_sum::name[];
 
 constexpr ObisId power_delivered_l1::id;
 constexpr char power_delivered_l1::name[];
@@ -188,6 +297,39 @@ constexpr char power_returned_l2::name[];
 
 constexpr ObisId power_returned_l3::id;
 constexpr char power_returned_l3::name[];
+
+constexpr ObisId apparent_delivery_power::id;
+constexpr char apparent_delivery_power::name[];
+
+constexpr ObisId apparent_delivery_power_l1::id;
+constexpr char apparent_delivery_power_l1::name[];
+
+constexpr ObisId apparent_delivery_power_l2::id;
+constexpr char apparent_delivery_power_l2::name[];
+
+constexpr ObisId apparent_delivery_power_l3::id;
+constexpr char apparent_delivery_power_l3::name[];
+
+constexpr ObisId apparent_return_power::id;
+constexpr char apparent_return_power::name[];
+
+constexpr ObisId apparent_return_power_l1::id;
+constexpr char apparent_return_power_l1::name[];
+
+constexpr ObisId apparent_return_power_l2::id;
+constexpr char apparent_return_power_l2::name[];
+
+constexpr ObisId apparent_return_power_l3::id;
+constexpr char apparent_return_power_l3::name[];
+
+constexpr ObisId active_demand_power::id;
+constexpr char active_demand_power::name[];
+
+constexpr ObisId active_demand_net::id;
+constexpr char active_demand_net::name[];
+
+constexpr ObisId active_demand_abs::id;
+constexpr char active_demand_abs::name[];
 
 /* LUX */
 constexpr ObisId reactive_power_delivered_l1::id;
@@ -272,8 +414,23 @@ constexpr char sub_delivered::name[];
 constexpr ObisId active_energy_import_current_average_demand::id;
 constexpr char active_energy_import_current_average_demand::name[];
 
+constexpr ObisId active_energy_export_current_average_demand::id;
+constexpr char active_energy_export_current_average_demand::name[];
+
 constexpr ObisId active_energy_import_maximum_demand_running_month::id;
 constexpr char active_energy_import_maximum_demand_running_month::name[];
 
 constexpr ObisId active_energy_import_maximum_demand_last_13_months::id;
 constexpr char active_energy_import_maximum_demand_last_13_months::name[];
+
+constexpr ObisId fw_core_version::id;
+constexpr char fw_core_version::name[];
+
+constexpr ObisId fw_core_checksum::id;
+constexpr char fw_core_checksum::name[];
+
+constexpr ObisId fw_module_version::id;
+constexpr char fw_module_version::name[];
+
+constexpr ObisId fw_module_checksum::id;
+constexpr char fw_module_checksum::name[];

--- a/src/dsmr/fields.cpp
+++ b/src/dsmr/fields.cpp
@@ -417,6 +417,30 @@ constexpr char active_energy_import_current_average_demand::name[];
 constexpr ObisId active_energy_export_current_average_demand::id;
 constexpr char active_energy_export_current_average_demand::name[];
 
+constexpr ObisId apparent_energy_import_current_average_demand::id;
+constexpr char apparent_energy_import_current_average_demand::name[];
+
+constexpr ObisId apparent_energy_export_current_average_demand::id;
+constexpr char apparent_energy_export_current_average_demand::name[];
+
+constexpr ObisId active_energy_import_last_completed_demand::id;
+constexpr char active_energy_import_last_completed_demand::name[];
+
+constexpr ObisId active_energy_export_last_completed_demand::id;
+constexpr char active_energy_export_last_completed_demand::name[];
+
+constexpr ObisId reactive_energy_import_last_completed_demand::id;
+constexpr char reactive_energy_import_last_completed_demand::name[];
+
+constexpr ObisId reactive_energy_export_last_completed_demand::id;
+constexpr char reactive_energy_export_last_completed_demand::name[];
+
+constexpr ObisId apparent_energy_import_last_completed_demand::id;
+constexpr char apparent_energy_import_last_completed_demand::name[];
+
+constexpr ObisId apparent_energy_export_last_completed_demand::id;
+constexpr char apparent_energy_export_last_completed_demand::name[];
+
 constexpr ObisId active_energy_import_maximum_demand_running_month::id;
 constexpr char active_energy_import_maximum_demand_running_month::name[];
 

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -558,6 +558,16 @@ namespace dsmr
     /*Current quart-hourly energy consumption*/
     DEFINE_FIELD(active_energy_import_current_average_demand, FixedValue, ObisId(1, 0, 1, 4, 0), FixedField, units::kW, units::W);
     DEFINE_FIELD(active_energy_export_current_average_demand, FixedValue, ObisId(1, 0, 2, 4, 0), FixedField, units::kW, units::W);
+    DEFINE_FIELD(reactive_energy_import_current_average_demand, FixedValue, ObisId(1, 0, 3, 4, 0), FixedField, units::kvar, units::kvar);
+    DEFINE_FIELD(reactive_energy_export_current_average_demand, FixedValue, ObisId(1, 0, 4, 4, 0), FixedField, units::kvar, units::kvar);
+    DEFINE_FIELD(apparent_energy_import_current_average_demand, FixedValue, ObisId(1, 0, 9, 4, 0), FixedField, units::kVA, units::VA);
+    DEFINE_FIELD(apparent_energy_export_current_average_demand, FixedValue, ObisId(1, 0, 10, 4, 0), FixedField, units::kVA, units::VA);
+    DEFINE_FIELD(active_energy_import_last_completed_demand, FixedValue, ObisId(1, 0, 1, 5, 0), FixedField, units::kW, units::W);
+    DEFINE_FIELD(active_energy_export_last_completed_demand, FixedValue, ObisId(1, 0, 2, 5, 0), FixedField, units::kW, units::W);
+    DEFINE_FIELD(reactive_energy_import_last_completed_demand, FixedValue, ObisId(1, 0, 3, 5, 0), FixedField, units::kvar, units::kvar);
+    DEFINE_FIELD(reactive_energy_export_last_completed_demand, FixedValue, ObisId(1, 0, 4, 5, 0), FixedField, units::kvar, units::kvar);
+    DEFINE_FIELD(apparent_energy_import_last_completed_demand, FixedValue, ObisId(1, 0, 9, 5, 0), FixedField, units::kVA, units::VA);
+    DEFINE_FIELD(apparent_energy_export_last_completed_demand, FixedValue, ObisId(1, 0, 10, 5, 0), FixedField, units::kVA, units::VA);
 
     /*Maximum energy consumption from the current month*/
     DEFINE_FIELD(active_energy_import_maximum_demand_running_month, TimestampedFixedValue, ObisId(1, 0, 1, 6, 0), TimestampedFixedField, units::kW, units::W);

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -228,8 +228,10 @@ namespace dsmr
       static constexpr char Wh[] = "Wh";
       static constexpr char kW[] = "kW";
       static constexpr char W[] = "W";
+      static constexpr char kV[] = "kV";
       static constexpr char V[] = "V";
       static constexpr char mV[] = "mV";
+      static constexpr char kA[] = "kA";
       static constexpr char A[] = "A";
       static constexpr char mA[] = "mA";
       static constexpr char m3[] = "m3";
@@ -238,6 +240,11 @@ namespace dsmr
       static constexpr char MJ[] = "MJ";
       static constexpr char kvar[] = "kvar";
       static constexpr char kvarh[] = "kvarh";
+      static constexpr char kVA[] = "kVA";
+      static constexpr char VA[] = "VA";
+      static constexpr char s[] = "s";
+      static constexpr char Hz[] ="Hz";
+      static constexpr char kHz[] ="kHz";
     };
 
     const uint8_t GAS_MBUS_ID = DSMR_GAS_MBUS_ID;
@@ -271,23 +278,49 @@ namespace dsmr
     DEFINE_FIELD(equipment_id, String, ObisId(0, 0, 96, 1, 1), StringField, 0, 96);
 
     /* Meter Reading electricity delivered to client (Special for Lux) in 0,001 kWh */
+    /* TODO: by OBIS 1-0:1.8.0.255 IEC 62056 it should be Positive active energy (A+) total [kWh], should we rename it? */
     DEFINE_FIELD(energy_delivered_lux, FixedValue, ObisId(1, 0, 1, 8, 0), FixedField, units::kWh, units::Wh);
     /* Meter Reading electricity delivered to client (Tariff 1) in 0,001 kWh */
     DEFINE_FIELD(energy_delivered_tariff1, FixedValue, ObisId(1, 0, 1, 8, 1), FixedField, units::kWh, units::Wh);
     /* Meter Reading electricity delivered to client (Tariff 2) in 0,001 kWh */
     DEFINE_FIELD(energy_delivered_tariff2, FixedValue, ObisId(1, 0, 1, 8, 2), FixedField, units::kWh, units::Wh);
+    /* Meter Reading electricity delivered to client (Tariff 3) in 0,001 kWh *
+    DEFINE_FIELD(energy_delivered_tariff3, FixedValue, ObisId(1, 0, 1, 8, 3), FixedField, units::kWh, units::Wh);
+    /* Meter Reading electricity delivered to client (Tariff 4) in 0,001 kWh */
+    DEFINE_FIELD(energy_delivered_tariff4, FixedValue, ObisId(1, 0, 1, 8, 4), FixedField, units::kWh, units::Wh);
     /* Meter Reading electricity delivered by client (Special for Lux) in 0,001 kWh */
+    /* TODO: by OBIS 1-0:2.8.0.255 IEC 62056 it should be Negative active energy (A+) total [kWh], should we rename it? */
     DEFINE_FIELD(energy_returned_lux, FixedValue, ObisId(1, 0, 2, 8, 0), FixedField, units::kWh, units::Wh);
     /* Meter Reading electricity delivered by client (Tariff 1) in 0,001 kWh */
     DEFINE_FIELD(energy_returned_tariff1, FixedValue, ObisId(1, 0, 2, 8, 1), FixedField, units::kWh, units::Wh);
     /* Meter Reading electricity delivered by client (Tariff 2) in 0,001 kWh */
     DEFINE_FIELD(energy_returned_tariff2, FixedValue, ObisId(1, 0, 2, 8, 2), FixedField, units::kWh, units::Wh);
-
+    /* Meter Reading electricity delivered by client (Tariff 1) in 0,001 kWh */
+    DEFINE_FIELD(energy_returned_tariff3, FixedValue, ObisId(1, 0, 2, 8, 3), FixedField, units::kWh, units::Wh);
+    /* Meter Reading electricity delivered by client (Tariff 2) in 0,001 kWh */
+    DEFINE_FIELD(energy_returned_tariff4, FixedValue, ObisId(1, 0, 2, 8, 4), FixedField, units::kWh, units::Wh);
     /*
- * Extra fields used for Luxembourg
+ * Extra fields used for Luxembourg and Lithuania
  */
     DEFINE_FIELD(total_imported_energy, FixedValue, ObisId(1, 0, 3, 8, 0), FixedField, units::kvarh, units::kvarh);
+    /* Meter Reading Reactive energy delivered to client (Tariff 1) in 0,001 kvarh */
+    DEFINE_FIELD(reactive_energy_delivered_tariff1, FixedValue, ObisId(1, 0, 3, 8, 1), FixedField, units::kvarh, units::kvarh);
+    /* Meter Reading Reactive energy delivered to client (Tariff 2) in 0,001 kvarh */
+    DEFINE_FIELD(reactive_energy_delivered_tariff2, FixedValue, ObisId(1, 0, 3, 8, 2), FixedField, units::kvarh, units::kvarh);
+    /* Meter Reading Reactive energy delivered to client (Tariff 3) in 0,001 kvarh */
+    DEFINE_FIELD(reactive_energy_delivered_tariff3, FixedValue, ObisId(1, 0, 3, 8, 3), FixedField, units::kvarh, units::kvarh);
+    /* Meter Reading Reactive energy delivered to client (Tariff 4) in 0,001 kvarh */
+    DEFINE_FIELD(reactive_energy_delivered_tariff4, FixedValue, ObisId(1, 0, 3, 8, 4), FixedField, units::kvarh, units::kvarh);
+
     DEFINE_FIELD(total_exported_energy, FixedValue, ObisId(1, 0, 4, 8, 0), FixedField, units::kvarh, units::kvarh);
+    /* Meter Reading Reactive energy delivered by client (Tariff 1) in 0,001 kvarh */
+    DEFINE_FIELD(reactive_energy_returned_tariff1, FixedValue, ObisId(1, 0, 4, 8, 1), FixedField, units::kvarh, units::kvarh);
+    /* Meter Reading Reactive energy delivered by client (Tariff 2) in 0,001 kvarh */
+    DEFINE_FIELD(reactive_energy_returned_tariff2, FixedValue, ObisId(1, 0, 4, 8, 2), FixedField, units::kvarh, units::kvarh);
+    /* Meter Reading Reactive energy delivered by client (Tariff 3) in 0,001 kvarh */
+    DEFINE_FIELD(reactive_energy_returned_tariff3, FixedValue, ObisId(1, 0, 4, 8, 3), FixedField, units::kvarh, units::kvarh);
+    /* Meter Reading Reactive energy delivered by client (Tariff 4) in 0,001 kvarh */
+    DEFINE_FIELD(reactive_energy_returned_tariff4, FixedValue, ObisId(1, 0, 4, 8, 4), FixedField, units::kvarh, units::kvarh);
 
     /* Tariff indicator electricity. The tariff indicator can also be used
  * to switch tariff dependent loads e.g boilers. This is the
@@ -300,7 +333,7 @@ namespace dsmr
     DEFINE_FIELD(power_returned, FixedValue, ObisId(1, 0, 2, 7, 0), FixedField, units::kW, units::W);
 
     /*
- * Extra fields used for Luxembourg
+ * Extra fields used for Luxembourg and Lithuania
  */
     DEFINE_FIELD(reactive_power_delivered, FixedValue, ObisId(1, 0, 3, 7, 0), FixedField, units::kvar, units::kvar);
     DEFINE_FIELD(reactive_power_returned, FixedValue, ObisId(1, 0, 4, 7, 0), FixedField, units::kvar, units::kvar);
@@ -321,17 +354,33 @@ namespace dsmr
 
     /* Number of voltage sags in phase L1 */
     DEFINE_FIELD(electricity_sags_l1, uint32_t, ObisId(1, 0, 32, 32, 0), IntField, units::none);
+    DEFINE_FIELD(voltage_sag_time_l1, uint32_t, ObisId(1, 0, 32, 33, 0), IntField, units::s);
+    DEFINE_FIELD(voltage_sag_l1, uint32_t, ObisId(1, 0, 32, 34, 0), IntField, units::V);
+
     /* Number of voltage sags in phase L2 (polyphase meters only) */
     DEFINE_FIELD(electricity_sags_l2, uint32_t, ObisId(1, 0, 52, 32, 0), IntField, units::none);
+    DEFINE_FIELD(voltage_sag_time_l2, uint32_t, ObisId(1, 0, 52, 33, 0), IntField, units::s);
+    DEFINE_FIELD(voltage_sag_l2, uint32_t, ObisId(1, 0, 52, 34, 0), IntField, units::V);
+
     /* Number of voltage sags in phase L3 (polyphase meters only) */
     DEFINE_FIELD(electricity_sags_l3, uint32_t, ObisId(1, 0, 72, 32, 0), IntField, units::none);
-
+    DEFINE_FIELD(voltage_sag_time_l3, uint32_t, ObisId(1, 0, 72, 33, 0), IntField, units::s);
+    DEFINE_FIELD(voltage_sag_l3, uint32_t, ObisId(1, 0, 72, 34, 0), IntField, units::V);
+   
     /* Number of voltage swells in phase L1 */
     DEFINE_FIELD(electricity_swells_l1, uint32_t, ObisId(1, 0, 32, 36, 0), IntField, units::none);
+    DEFINE_FIELD(voltage_swell_time_l1, uint32_t, ObisId(1, 0, 32, 37, 0), IntField, units::s);
+    DEFINE_FIELD(voltage_swell_l1, uint32_t, ObisId(1, 0, 32, 38, 0), IntField, units::V);
+
     /* Number of voltage swells in phase L2 (polyphase meters only) */
     DEFINE_FIELD(electricity_swells_l2, uint32_t, ObisId(1, 0, 52, 36, 0), IntField, units::none);
+    DEFINE_FIELD(voltage_swell_time_l2, uint32_t, ObisId(1, 0, 52, 37, 0), IntField, units::s);
+    DEFINE_FIELD(voltage_swell_l2, uint32_t, ObisId(1, 0, 52, 38, 0), IntField, units::V);
+
     /* Number of voltage swells in phase L3 (polyphase meters only) */
     DEFINE_FIELD(electricity_swells_l3, uint32_t, ObisId(1, 0, 72, 36, 0), IntField, units::none);
+    DEFINE_FIELD(voltage_swell_time_l3, uint32_t, ObisId(1, 0, 72, 37, 0), IntField, units::s);
+    DEFINE_FIELD(voltage_swell_l3, uint32_t, ObisId(1, 0, 72, 38, 0), IntField, units::V);
 
     /* Text message codes: numeric 8 digits (Note: Missing from 5.0 spec)
  * */
@@ -344,21 +393,34 @@ namespace dsmr
  * resolution in comment, but 0.1V resolution in format spec. Added in
  * 5.0) */
     DEFINE_FIELD(voltage_l1, FixedValue, ObisId(1, 0, 32, 7, 0), FixedField, units::V, units::mV);
+    DEFINE_FIELD(voltage_avg_l1, FixedValue, ObisId(1, 0, 32, 24, 0), FixedField, units::V, units::mV);
     /* Instantaneous voltage L2 in 0.1V resolution (Note: Spec says V
  * resolution in comment, but 0.1V resolution in format spec. Added in
  * 5.0) */
     DEFINE_FIELD(voltage_l2, FixedValue, ObisId(1, 0, 52, 7, 0), FixedField, units::V, units::mV);
+    DEFINE_FIELD(voltage_avg_l2, FixedValue, ObisId(1, 0, 52, 24, 0), FixedField, units::V, units::mV);
     /* Instantaneous voltage L3 in 0.1V resolution (Note: Spec says V
  * resolution in comment, but 0.1V resolution in format spec. Added in
  * 5.0) */
     DEFINE_FIELD(voltage_l3, FixedValue, ObisId(1, 0, 72, 7, 0), FixedField, units::V, units::mV);
+    DEFINE_FIELD(voltage_avg_l3, FixedValue, ObisId(1, 0, 72, 24, 0), FixedField, units::V, units::mV);
+
+    /* Instantaneous voltage (U) [V] */
+    DEFINE_FIELD(voltage, FixedValue, ObisId(1, 0, 12, 7, 0), FixedField, units::V, units::mV);
+    /* Frequency [Hz] */
+    DEFINE_FIELD(frequency, FixedValue, ObisId(1, 0, 14, 7, 0), FixedField, units::kHz, units::Hz);
+    /* Absolute active instantaneous power (|A|) [kW] */
+    DEFINE_FIELD(abs_power, FixedValue, ObisId(1, 0, 15, 7, 0), FixedField, units::kW, units::W);
 
     /* Instantaneous current L1 in A resolution */
     DEFINE_FIELD(current_l1, FixedValue, ObisId(1, 0, 31, 7, 0), FixedField, units::A, units::mA);
+    DEFINE_FIELD(current_fuse_l1, FixedValue, ObisId(1, 0, 31, 4, 0), FixedField, units::A, units::mA);
     /* Instantaneous current L2 in A resolution */
     DEFINE_FIELD(current_l2, FixedValue, ObisId(1, 0, 51, 7, 0), FixedField, units::A, units::mA);
+    DEFINE_FIELD(current_fuse_l2, FixedValue, ObisId(1, 0, 51, 4, 0), FixedField, units::A, units::mA);
     /* Instantaneous current L3 in A resolution */
     DEFINE_FIELD(current_l3, FixedValue, ObisId(1, 0, 71, 7, 0), FixedField, units::A, units::mA);
+    DEFINE_FIELD(current_fuse_l3, FixedValue, ObisId(1, 0, 71, 4, 0), FixedField, units::A, units::mA);
 
     /* Instantaneous active power L1 (+P) in W resolution */
     DEFINE_FIELD(power_delivered_l1, FixedValue, ObisId(1, 0, 21, 7, 0), FixedField, units::kW, units::W);
@@ -374,9 +436,17 @@ namespace dsmr
     /* Instantaneous active power L3 (-P) in W resolution */
     DEFINE_FIELD(power_returned_l3, FixedValue, ObisId(1, 0, 62, 7, 0), FixedField, units::kW, units::W);
 
+    /* Instantaneous current (I) [A] */
+    DEFINE_FIELD(current, FixedValue, ObisId(1, 0, 11, 7, 0), FixedField, units::kA, units::A);
+    /* Instantaneous current (I) in neutral [A] */
+    DEFINE_FIELD(current_n, FixedValue, ObisId(1, 0, 91, 7, 0), FixedField, units::kA, units::A);
+    /* Instantaneous sum of all phase current's  (I) [A] */
+    DEFINE_FIELD(current_sum, FixedValue, ObisId(1, 0, 90, 7, 0), FixedField, units::kA, units::A);
+
     /*
- * LUX
+ * LUX and Lithuania
  */
+    /* TODO: by IEC 62056 unit's shoudl be kvar, safe to change? */
     /* Instantaneous reactive power L1 (+Q) in W resolution */
     DEFINE_FIELD(reactive_power_delivered_l1, FixedValue, ObisId(1, 0, 23, 7, 0), FixedField, units::none, units::none);
     /* Instantaneous reactive power L2 (+Q) in W resolution */
@@ -385,14 +455,41 @@ namespace dsmr
     DEFINE_FIELD(reactive_power_delivered_l3, FixedValue, ObisId(1, 0, 63, 7, 0), FixedField, units::none, units::none);
 
     /*
- * LUX
+ * LUX and Lithuania
  */
+    /* TODO: by IEC 62056 unit's shoudl be kvar, safe to change? */
     /* Instantaneous reactive power L1 (-Q) in W resolution */
     DEFINE_FIELD(reactive_power_returned_l1, FixedValue, ObisId(1, 0, 24, 7, 0), FixedField, units::none, units::none);
     /* Instantaneous reactive power L2 (-Q) in W resolution */
     DEFINE_FIELD(reactive_power_returned_l2, FixedValue, ObisId(1, 0, 44, 7, 0), FixedField, units::none, units::none);
     /* Instantaneous reactive power L3 (-Q) in W resolution */
     DEFINE_FIELD(reactive_power_returned_l3, FixedValue, ObisId(1, 0, 64, 7, 0), FixedField, units::none, units::none);
+
+    /* Apparent instantaneous power (+S) in kVA resolution */
+    DEFINE_FIELD(apparent_delivery_power, FixedValue, ObisId(1, 0, 9, 7, 0), FixedField, units::kVA, units::VA);
+    /* Apparent instantaneous power L1 (+S) in kVA resolution */
+    DEFINE_FIELD(apparent_delivery_power_l1, FixedValue, ObisId(1, 0, 29, 7, 0), FixedField, units::kVA, units::VA);
+    /* Apparent instantaneous power L2 (+S) in kVA resolution */
+    DEFINE_FIELD(apparent_delivery_power_l2, FixedValue, ObisId(1, 0, 49, 7, 0), FixedField, units::kVA, units::VA);
+    /* Apparent instantaneous power L3 (+S) in kVA resolution */
+    DEFINE_FIELD(apparent_delivery_power_l3, FixedValue, ObisId(1, 0, 69, 7, 0), FixedField, units::kVA, units::VA);
+
+    /* Apparent instantaneous power (-S) in kVA resolution */
+    DEFINE_FIELD(apparent_return_power, FixedValue, ObisId(1, 0, 10, 7, 0), FixedField, units::kVA, units::VA);
+    /* Apparent instantaneous power L1 (-S) in kVA resolution */
+    DEFINE_FIELD(apparent_return_power_l1, FixedValue, ObisId(1, 0, 30, 7, 0), FixedField, units::kVA, units::VA);
+    /* Apparent instantaneous power L2 (-S) in kVA resolution */
+    DEFINE_FIELD(apparent_return_power_l2, FixedValue, ObisId(1, 0, 50, 7, 0), FixedField, units::kVA, units::VA);
+    /* Apparent instantaneous power L3 (-S) in kVA resolution */
+    DEFINE_FIELD(apparent_return_power_l3, FixedValue, ObisId(1, 0, 70, 7, 0), FixedField, units::kVA, units::VA);
+
+    /* Active Demand Avg3 Plus in W resolution */
+    DEFINE_FIELD(active_demand_power, FixedValue, ObisId(1, 0, 1, 24, 0), FixedField, units::kW, units::W);
+    /* Active Demand Avg3 Net in W resolution */
+    /* TODO: 1-0.16.24.0.255 can have negative value, this library is not ready for negative numbers. */
+    // DEFINE_FIELD(active_demand_net, int32_t, ObisId(1, 0, 16, 24, 0), IntField, units::kW);  
+    /* Active Demand Avg3 Absolute  in W resolution */
+    DEFINE_FIELD(active_demand_abs, FixedValue, ObisId(1, 0, 15, 24, 0), FixedField, units::kW, units::W);
 
     /* Device-Type */
     DEFINE_FIELD(gas_device_type, uint16_t, ObisId(0, GAS_MBUS_ID, 24, 1, 0), IntField, units::none);
@@ -460,11 +557,20 @@ namespace dsmr
     /* Extra fields used for Belgian capacity rate/peak consumption (cappaciteitstarief) */
     /*Current quart-hourly energy consumption*/
     DEFINE_FIELD(active_energy_import_current_average_demand, FixedValue, ObisId(1, 0, 1, 4, 0), FixedField, units::kW, units::W);
+    DEFINE_FIELD(active_energy_export_current_average_demand, FixedValue, ObisId(1, 0, 2, 4, 0), FixedField, units::kW, units::W);
+
     /*Maximum energy consumption from the current month*/
     DEFINE_FIELD(active_energy_import_maximum_demand_running_month, TimestampedFixedValue, ObisId(1, 0, 1, 6, 0), TimestampedFixedField, units::kW, units::W);
     /*Maximum energy consumption from the last 13 months*/
     DEFINE_FIELD(active_energy_import_maximum_demand_last_13_months, FixedValue, ObisId(0, 0, 98, 1, 0), LastFixedField, units::kW, units::W);
 
+    /* Image Core Version and checksum */
+    DEFINE_FIELD(fw_core_version, FixedValue, ObisId(1, 0, 0, 2, 0), FixedField, units::none, units::none);
+    DEFINE_FIELD(fw_core_checksum, String, ObisId(1, 0, 0, 2, 8), StringField, 0, 8);
+    /* Image Module Version and checksum */
+    DEFINE_FIELD(fw_module_version, FixedValue, ObisId(1, 1, 0, 2, 0), FixedField, units::none, units::none);
+    DEFINE_FIELD(fw_module_checksum, String, ObisId(1, 1, 0, 2, 8), StringField, 0, 8);
+      
   } // namespace fields
 
 } // namespace dsmr

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -284,7 +284,7 @@ namespace dsmr
     DEFINE_FIELD(energy_delivered_tariff1, FixedValue, ObisId(1, 0, 1, 8, 1), FixedField, units::kWh, units::Wh);
     /* Meter Reading electricity delivered to client (Tariff 2) in 0,001 kWh */
     DEFINE_FIELD(energy_delivered_tariff2, FixedValue, ObisId(1, 0, 1, 8, 2), FixedField, units::kWh, units::Wh);
-    /* Meter Reading electricity delivered to client (Tariff 3) in 0,001 kWh *
+    /* Meter Reading electricity delivered to client (Tariff 3) in 0,001 kWh */
     DEFINE_FIELD(energy_delivered_tariff3, FixedValue, ObisId(1, 0, 1, 8, 3), FixedField, units::kWh, units::Wh);
     /* Meter Reading electricity delivered to client (Tariff 4) in 0,001 kWh */
     DEFINE_FIELD(energy_delivered_tariff4, FixedValue, ObisId(1, 0, 1, 8, 4), FixedField, units::kWh, units::Wh);
@@ -437,11 +437,11 @@ namespace dsmr
     DEFINE_FIELD(power_returned_l3, FixedValue, ObisId(1, 0, 62, 7, 0), FixedField, units::kW, units::W);
 
     /* Instantaneous current (I) [A] */
-    DEFINE_FIELD(current, FixedValue, ObisId(1, 0, 11, 7, 0), FixedField, units::kA, units::A);
+    DEFINE_FIELD(current, FixedValue, ObisId(1, 0, 11, 7, 0), FixedField, units::A, units::mA);
     /* Instantaneous current (I) in neutral [A] */
-    DEFINE_FIELD(current_n, FixedValue, ObisId(1, 0, 91, 7, 0), FixedField, units::kA, units::A);
+    DEFINE_FIELD(current_n, FixedValue, ObisId(1, 0, 91, 7, 0), FixedField, units::A, units::mA);
     /* Instantaneous sum of all phase current's  (I) [A] */
-    DEFINE_FIELD(current_sum, FixedValue, ObisId(1, 0, 90, 7, 0), FixedField, units::kA, units::A);
+    DEFINE_FIELD(current_sum, FixedValue, ObisId(1, 0, 90, 7, 0), FixedField, units::A, units::mA);
 
     /*
  * LUX and Lithuania


### PR DESCRIPTION
Lithuania is ready to join smart meter community :) I have noticed that couple of OBIS we get is marked as LUX.. But according to specification they have standard meaning's and values.. is it possible to replace them to more meaning?  Also for now we have some values auto of specifications, we get kV (kilo volts) instead of volts, kA (kilo amps) instead of amps, and I think kHz instead of Hz.. Operator told that it will be fixed in near feature.. so i will leave all values in Volt's and Amps.. 

[OBIS meaning's in native language ](https://ismaniejiskaitikliai.lt/data/public/uploads/2023/02/smart-duomenu-tvarkymo-taisykles.pdf)


Here is full telemetry we get from our smart meeter:
```
/ESO5\\XxXxXxXxXxX

0-0:1.0.0(230808113811S)
1-0:1.8.0(00009548.086*kWh)
1-0:3.8.0(00000026.348*kvarh)
1-0:4.8.0(00005851.642*kvarh)
1-0:1.8.1(00009548.086*kWh)
1-0:1.8.2(00000000.000*kWh)
1-0:1.8.3(00000000.000*kWh)
1-0:1.8.4(00000000.000*kWh)
1-0:2.8.1(00007251.697*kWh)
1-0:2.8.2(00000000.000*kWh)
1-0:2.8.3(00000000.000*kWh)
1-0:2.8.4(00000000.000*kWh)
1-0:3.8.1(00000026.348*kvarh)
1-0:3.8.2(00000000.000*kvarh)
1-0:3.8.3(00000000.000*kvarh)
1-0:3.8.4(00000000.000*kvarh)
1-0:4.8.1(00005851.642*kvarh)
1-0:4.8.2(00000000.000*kvarh)
1-0:4.8.3(00000000.000*kvarh)
1-0:4.8.4(00000000.000*kvarh)
1-0:32.7.0(0000.242*kV)
1-0:32.24.0(0000.237*kV)
1-0:31.7.0(0000.005*kA)
1-0:31.4.0(0000.003*kA)
1-0:52.7.0(0000.228*kV)
1-0:52.24.0(0000.227*kV)
1-0:51.7.0(0000.004*kA)
1-0:51.4.0(0000.002*kA)
1-0:72.7.0(0000.239*kV)
1-0:72.24.0(0000.236*kV)
1-0:71.7.0(0000.004*kA)
1-0:71.4.0(0000.002*kA)
1-0:12.7.0(0000.242*kV)
1-0:11.7.0(0000.005*kA)
1-0:91.7.0(0000.000*kA)
1-0:90.7.0(0000.014*kA)
1-0:14.7.0(0000.049*kHz)
1-0:15.7.0(00000003.262*kW)
1-0:21.7.0(00000000.000*kW)
1-0:41.7.0(00000000.000*kW)
1-0:61.7.0(00000000.000*kW)
1-0:22.7.0(00000001.186*kW)
1-0:42.7.0(00000001.061*kW)
1-0:62.7.0(00000001.014*kW)
1-0:23.7.0(00000000.000*kvar)
1-0:43.7.0(00000000.000*kvar)
1-0:63.7.0(00000000.000*kvar)
1-0:24.7.0(00000000.263*kvar)
1-0:44.7.0(00000000.173*kvar)
1-0:64.7.0(00000000.271*kvar)
1-0:9.7.0(00000000.000*kVA)
1-0:29.7.0(00000000.000*kVA)
1-0:49.7.0(00000000.000*kVA)
1-0:69.7.0(00000000.000*kVA)
1-0:10.7.0(00000003.350*kVA)
1-0:30.7.0(00000001.218*kVA)
1-0:50.7.0(00000001.077*kVA)
1-0:70.7.0(00000001.054*kVA)
1-0:1.24.0(00000000.000*kW)
1-0:16.24.0(-40*kW)
1-0:15.24.0(00000003.053*kW)
1-0:13.7.0(-977)
1-0:33.7.0(-973)
1-0:53.7.0(-985)
1-0:73.7.0(-962)
1-0:13.3.0(00000)
1-0:0.8.2(00900*s)
1-0:1.4.0(00000000.000*kW)
1-0:2.4.0(00000001.904*kW)
1-0:3.4.0(00000000.000*kvar)
1-0:4.4.0(00000000.390*kvar)
1-0:9.4.0(00000000.000*kVA)
1-0:10.4.0(00000001.956*kVA)
1-0:1.5.0(00000000.000*kW)
1-0:2.5.0(00000002.538*kW)
1-0:3.5.0(00000000.000*kvar)
1-0:4.5.0(00000000.679*kvar)
1-0:9.5.0(00000000.000*kVA)
1-0:10.5.0(00000002.661*kVA)
0-0:96.7.21(00036)
1-0:32.33.0(00230*s)
1-0:52.33.0(00231*s)
1-0:72.33.0(00230*s)
1-0:32.34.0(00000*V)
1-0:52.34.0(00000*V)
1-0:72.34.0(00000*V)
1-0:32.37.0(00000*s)
1-0:52.37.0(00000*s)
1-0:72.37.0(00000*s)
1-0:32.38.0(00000*V)
1-0:52.38.0(00000*V)
1-0:72.38.0(00000*V)
1-0:0.2.0(02.21)
1-0:0.2.8(1EA43311)
1-1:0.2.0(01.97)
1-1:0.2.8(68860C25)
!CRC
```


