### PR TITLE
Add OBIS codes for Switzerland

### DIFF
--- a/src/dsmr/fields.cpp
+++ b/src/dsmr/fields.cpp
@@ -70,6 +70,10 @@ constexpr char p1_version::name[];
 constexpr ObisId p1_version_be::id;
 constexpr char p1_version_be::name[];
 
+/* extra field for Switzerland */
+constexpr ObisId p1_version_ch::id;
+constexpr char p1_version_ch::name[];
+
 constexpr ObisId timestamp::id;
 constexpr char timestamp::name[];
 
@@ -104,6 +108,14 @@ constexpr char reactive_energy_delivered_tariff3::name[];
 constexpr ObisId reactive_energy_delivered_tariff4::id;
 constexpr char reactive_energy_delivered_tariff4::name[];
 
+/* specific for Switzerland */
+constexpr ObisId energy_delivered_tariff1_ch::id;
+constexpr char energy_delivered_tariff1_ch::name[];
+
+/* specific for Switzerland */
+constexpr ObisId energy_delivered_tariff2_ch::id;
+constexpr char energy_delivered_tariff2_ch::name[];
+
 /* extra for Lux */
 constexpr ObisId energy_returned_lux::id;
 constexpr char energy_returned_lux::name[];
@@ -132,6 +144,14 @@ constexpr char reactive_energy_returned_tariff3::name[];
 constexpr ObisId reactive_energy_returned_tariff4::id;
 constexpr char reactive_energy_returned_tariff4::name[];
 
+/* specific for Switzerland */
+constexpr ObisId energy_returned_tariff1_ch::id;
+constexpr char energy_returned_tariff1_ch::name[];
+
+/* specific for Switzerland */
+constexpr ObisId energy_returned_tariff2_ch::id;
+constexpr char energy_returned_tariff2_ch::name[];
+
 /* extra for Lux */
 constexpr ObisId total_imported_energy::id;
 constexpr char total_imported_energy::name[];
@@ -156,6 +176,14 @@ constexpr char power_delivered::name[];
 
 constexpr ObisId power_returned::id;
 constexpr char power_returned::name[];
+
+/* specific for Switzerland */
+constexpr ObisId power_delivered_ch::id;
+constexpr char power_delivered_ch::name[];
+
+/* specific for Switzerland */
+constexpr ObisId power_returned_ch::id;
+constexpr char power_returned_ch::name[];
 
 constexpr ObisId electricity_threshold::id;
 constexpr char electricity_threshold::name[];

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -270,6 +270,7 @@ namespace dsmr
     /* Version information for P1 output */
     DEFINE_FIELD(p1_version, String, ObisId(1, 3, 0, 2, 8), StringField, 2, 2);
     DEFINE_FIELD(p1_version_be, String, ObisId(0, 0, 96, 1, 4), StringField, 2, 96);
+    DEFINE_FIELD(p1_version_ch, String, ObisId(0, 0, 96, 1, 4), StringField, 2, 96);
 
     /* Date-time stamp of the P1 message */
     DEFINE_FIELD(timestamp, String, ObisId(0, 0, 1, 0, 0), TimestampField);
@@ -322,6 +323,18 @@ namespace dsmr
     /* Meter Reading Reactive energy delivered by client (Tariff 4) in 0,001 kvarh */
     DEFINE_FIELD(reactive_energy_returned_tariff4, FixedValue, ObisId(1, 0, 4, 8, 4), FixedField, units::kvarh, units::kvarh);
 
+    /*
+ * Specific fields used for Switzerland
+ */
+    /* Meter Reading electricity delivered to client (Tariff 1) in 0,001 kWh */
+    DEFINE_FIELD(energy_delivered_tariff1_ch, FixedValue, ObisId(1, 1, 1, 8, 1), FixedField, units::kWh, units::Wh);
+    /* Meter Reading electricity delivered to client (Tariff 2) in 0,001 kWh */
+    DEFINE_FIELD(energy_delivered_tariff2_ch, FixedValue, ObisId(1, 1, 1, 8, 2), FixedField, units::kWh, units::Wh);
+    /* Meter Reading electricity delivered by client (Tariff 1) in 0,001 kWh */
+    DEFINE_FIELD(energy_returned_tariff1_ch, FixedValue, ObisId(1, 1, 2, 8, 1), FixedField, units::kWh, units::Wh);
+    /* Meter Reading electricity delivered by client (Tariff 2) in 0,001 kWh */
+    DEFINE_FIELD(energy_returned_tariff2_ch, FixedValue, ObisId(1, 1, 2, 8, 2), FixedField, units::kWh, units::Wh);
+
     /* Tariff indicator electricity. The tariff indicator can also be used
  * to switch tariff dependent loads e.g boilers. This is the
  * responsibility of the P1 user */
@@ -337,6 +350,14 @@ namespace dsmr
  */
     DEFINE_FIELD(reactive_power_delivered, FixedValue, ObisId(1, 0, 3, 7, 0), FixedField, units::kvar, units::kvar);
     DEFINE_FIELD(reactive_power_returned, FixedValue, ObisId(1, 0, 4, 7, 0), FixedField, units::kvar, units::kvar);
+
+    /*
+ * Specific fields used for Switzerland
+ */
+    /* Actual electricity power delivered (+P) in 1 Watt resolution */
+    DEFINE_FIELD(power_delivered_ch, FixedValue, ObisId(1, 1, 1, 7, 0), FixedField, units::kW, units::W);
+    /* Actual electricity power received (-P) in 1 Watt resolution */
+    DEFINE_FIELD(power_returned_ch, FixedValue, ObisId(1, 1, 2, 7, 0), FixedField, units::kW, units::W);
 
     /* The actual threshold Electricity in kW. Removed in 4.0.7 / 4.2.2 / 5.0 */
     DEFINE_FIELD(electricity_threshold, FixedValue, ObisId(0, 0, 17, 0, 0), FixedField, units::kW, units::W);


### PR DESCRIPTION
According to https://www.strom.ch/sites/default/files/media/documents/20220511-rb-metering-code-ch.pdf (page 52), the second value of the OBIS code can only be 1, 3 or 5 in Switzerland.
This PR has been tested using homeassistant ESPHome and an electricity meter from Groupe E.