### PR TITLE
Add support for Elenia HAN interface

### DIFF
--- a/library.json
+++ b/library.json
@@ -5,7 +5,7 @@
   "keywords": "dsmr",
   "repository": {
     "type": "git",
-    "url": "https://github.com/glmnet/arduino-dsmr.git"
+    "url": "https://github.com/teerytko/arduino-dsmr.git"
   },
   "license": "MIT",
   "exclude": ["specs/"]

--- a/src/dsmr/parser.h
+++ b/src/dsmr/parser.h
@@ -405,8 +405,9 @@ namespace dsmr
           // passed '3' here (which is mandatory for "mode D"
           // communication according to 62956-21), so we also allow
           // that.
-          if (line_start + 3 >= line_end || (line_start[3] != '5' && line_start[3] != '3'))
-            return res.fail("Invalid identification string", line_start);
+          // Add Elenia H1 port identfier support ADN9
+          if (line_start + 3 >= line_end || (line_start[3] != '5' && line_start[3] != '3' && line_start[3] != '9'))
+            return res.fail("Invalid identification string, TeemuR: ", line_start);
           // Offer it for processing using the all-ones Obis ID, which
           // is not otherwise valid.
           ParseResult<void> tmp = data->parse_line(ObisId(255, 255, 255, 255, 255, 255), line_start, line_end);


### PR DESCRIPTION
The Elenia implemented slight deviation to the identification string in the HAN ESD interface. This change enables the functionality in Finland with Elenia power meters.