### PR TITLE
Add var and varh for austrian Smart meter of Energie Steiermark

### DIFF
--- a/src/dsmr/fields.cpp
+++ b/src/dsmr/fields.cpp
@@ -268,3 +268,9 @@ constexpr char sub_valve_position::name[];
 
 constexpr ObisId sub_delivered::id;
 constexpr char sub_delivered::name[];
+
+constexpr ObisId active_energy_import_current_average_demand::id;
+constexpr char active_energy_import_current_average_demand::name[];
+
+constexpr ObisId active_energy_import_maximum_demand_running_month::id;
+constexpr char active_energy_import_maximum_demand_running_month::name[];

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -210,7 +210,9 @@ namespace dsmr
       static constexpr char dm3[] = "dm3";
       static constexpr char GJ[] = "GJ";
       static constexpr char MJ[] = "MJ";
+      static constexpr char var[] = "var";
       static constexpr char kvar[] = "kvar";
+      static constexpr char varh[] = "varh";
       static constexpr char kvarh[] = "kvarh";
     };
 

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -262,8 +262,8 @@ namespace dsmr
     /*
  * Extra fields used for Luxembourg
  */
-    DEFINE_FIELD(total_imported_energy, FixedValue, ObisId(1, 0, 3, 8, 0), FixedField, units::kvarh, units::kvarh);
-    DEFINE_FIELD(total_exported_energy, FixedValue, ObisId(1, 0, 4, 8, 0), FixedField, units::kvarh, units::kvarh);
+    DEFINE_FIELD(total_imported_energy, FixedValue, ObisId(1, 0, 3, 8, 0), FixedField, units::kvarh, units::varh);
+    DEFINE_FIELD(total_exported_energy, FixedValue, ObisId(1, 0, 4, 8, 0), FixedField, units::kvarh, units::varh);
 
     /* Tariff indicator electricity. The tariff indicator can also be used
  * to switch tariff dependent loads e.g boilers. This is the
@@ -278,8 +278,8 @@ namespace dsmr
     /*
  * Extra fields used for Luxembourg
  */
-    DEFINE_FIELD(reactive_power_delivered, FixedValue, ObisId(1, 0, 3, 7, 0), FixedField, units::kvar, units::kvar);
-    DEFINE_FIELD(reactive_power_returned, FixedValue, ObisId(1, 0, 4, 7, 0), FixedField, units::kvar, units::kvar);
+    DEFINE_FIELD(reactive_power_delivered, FixedValue, ObisId(1, 0, 3, 7, 0), FixedField, units::kvar, units::var);
+    DEFINE_FIELD(reactive_power_returned, FixedValue, ObisId(1, 0, 4, 7, 0), FixedField, units::kvar, units::var);
 
     /* The actual threshold Electricity in kW. Removed in 4.0.7 / 4.2.2 / 5.0 */
     DEFINE_FIELD(electricity_threshold, FixedValue, ObisId(0, 0, 17, 0, 0), FixedField, units::kW, units::W);

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -431,6 +431,12 @@ namespace dsmr
     DEFINE_FIELD(sub_delivered, TimestampedFixedValue, ObisId(0, SUB_MBUS_ID, 24, 2, 1), TimestampedFixedField,
                  units::m3, units::dm3);
 
+    /* Extra fields used for Belgian capacity rate/peak consumption (cappaciteitstarief) */
+    /*Current quart-hourly energy consumption*/
+    DEFINE_FIELD(active_energy_import_current_average_demand, FixedValue, ObisId(1, 0, 1, 4, 0), FixedField, units::kW, units::W);
+    /*Maximum energy consumption from the current month*/
+    DEFINE_FIELD(active_energy_import_maximum_demand_running_month, TimestampedFixedValue, ObisId(1, 0, 1, 6, 0), TimestampedFixedField, units::kW, units::W);
+
   } // namespace fields
 
 } // namespace dsmr

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -236,7 +236,7 @@ namespace dsmr
 
     /* Version information for P1 output */
     DEFINE_FIELD(p1_version, String, ObisId(1, 3, 0, 2, 8), StringField, 2, 2);
-    DEFINE_FIELD(p1_version_be, String, ObisId(0, 0, 96, 1, 4), StringField, 2, 5);
+    DEFINE_FIELD(p1_version_be, String, ObisId(0, 0, 96, 1, 4), StringField, 2, 96);
 
     /* Date-time stamp of the P1 message */
     DEFINE_FIELD(timestamp, String, ObisId(0, 0, 1, 0, 0), TimestampField);


### PR DESCRIPTION
A readout of Austrian power meters from energy supplier `Energie Steiermark` is only possible with that change.
Type of smart meter:
`Sagemcom T210-D`

[smart meter documentation](https://www.e-netze.at/strom/smartmeter/Default.aspx)

This change is tested with 3 different smart meters of that type.

BR Daniel