### PR TITLE
Bump version to 0.10

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "Dsmr",
-  "version": "0.9",
+  "version": "0.10",
   "description": "Parser and utilities for Dutch Smart Meters (Implementing DSMR)",
   "keywords": "dsmr",
   "repository": {


### PR DESCRIPTION
- Will hopefully enable ESPHome to update to this new version, supporting Groupe E OBIS codes