### PR TITLE
Relax the parser to match units case insensitive

### DIFF
--- a/src/dsmr/parser.h
+++ b/src/dsmr/parser.h
@@ -221,7 +221,7 @@ namespace dsmr
         const char *unit_start = ++num_end; // skip *
         while (num_end < end && *num_end != ')' && *unit)
         {
-          if (*num_end++ != *unit++)
+          if (tolower(*num_end++) != tolower(*unit++))
             return res.fail(INVALID_UNIT, unit_start);
         }
         if (*unit)


### PR DESCRIPTION
Some meters like the Landis+Gyr E360 reports some units in mixed case format. For example depending on meter brand reactive power/energy can be output as kVar/kVarh or even kVAr/kVArh instead of the correct kvar/kvarh.

This patch resolves this by relaxing the parser to match units case insensitive.

The patch has been tested and units verified to work with ESPHome and Home Assistant.