### PR TITLE
Add decryption implementation using BearSsl. Decrypt inplace.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,14 @@
 cmake_minimum_required (VERSION 3.20)
-project(arduino-dsmr-test LANGUAGES CXX)
+project(arduino-dsmr-test LANGUAGES CXX C)
 include(FetchContent)
 
+# doctest
 file(DOWNLOAD
   https://github.com/doctest/doctest/releases/download/v2.4.12/doctest.h
   ${CMAKE_BINARY_DIR}/doctest/doctest.h
   EXPECTED_MD5 0671bbca9fb00cb19a168cffa89ac184)
 
+# mbedtls
 FetchContent_Populate(
   mded_tls
   URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.4/mbedtls-3.6.4.tar.bz2
@@ -15,6 +17,16 @@ set(ENABLE_PROGRAMS OFF CACHE INTERNAL "")
 set(ENABLE_TESTING OFF CACHE INTERNAL "")
 add_subdirectory(${mded_tls_SOURCE_DIR})
 
+# bearssl
+FetchContent_Populate(
+  bearsll
+  URL https://bearssl.org/bearssl-0.6.tar.gz
+  URL_HASH MD5=1513f9828c5b174ea409ca581cb45c98)
+file(GLOB_RECURSE bearssl_sources CONFIGURE_DEPENDS "${bearsll_SOURCE_DIR}/src/*.c")
+add_library(bearssl STATIC ${bearssl_sources})
+target_include_directories(bearssl SYSTEM PUBLIC "${bearsll_SOURCE_DIR}/inc" PRIVATE "${bearsll_SOURCE_DIR}/src")
+
+# cmake_template for warnings and sanitizers
 FetchContent_Populate(
   cmake_template
   URL https://github.com/cpp-best-practices/cmake_template/archive/refs/heads/main.zip
@@ -22,19 +34,18 @@ FetchContent_Populate(
 include(${cmake_template_SOURCE_DIR}/cmake/CompilerWarnings.cmake)
 include(${cmake_template_SOURCE_DIR}/cmake/Sanitizers.cmake)
 
+# arduino_dsmr_test
 file(GLOB_RECURSE arduino_dsmr_test_src_files CONFIGURE_DEPENDS "src/*.h" "src/*.cpp")
 add_executable(arduino_dsmr_test ${arduino_dsmr_test_src_files})
 target_include_directories(arduino_dsmr_test PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/doctest)
-target_include_directories(arduino_dsmr_test SYSTEM PRIVATE $<TARGET_PROPERTY:mbedtls,INTERFACE_INCLUDE_DIRECTORIES>)
 target_compile_features(arduino_dsmr_test PRIVATE cxx_std_20)
-target_link_libraries(arduino_dsmr_test PRIVATE mbedtls)
+target_link_libraries(arduino_dsmr_test PRIVATE mbedtls bearssl)
+target_include_directories(arduino_dsmr_test SYSTEM PUBLIC $<TARGET_PROPERTY:mbedtls,INTERFACE_INCLUDE_DIRECTORIES>) # disable warnings for mbedtls headers
+target_compile_options(arduino_dsmr_test PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/Zc:preprocessor>) # enable __VA_OPT__ on MSVC
 
 # enable warnings
 add_library(arduino_dsmr_test_warnings INTERFACE)
 myproject_set_project_warnings(arduino_dsmr_test_warnings ON "" "" "" "")
-if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-  target_compile_options(arduino_dsmr_test_warnings INTERFACE -Wno-gnu-zero-variadic-macro-arguments)
-endif()
 target_link_libraries(arduino_dsmr_test PRIVATE arduino_dsmr_test_warnings)
 
 # enable sanitizers: address, leak, undefined behaviour

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The primary goal is to make the parser independent of the Arduino framework and 
 # How to use
 ## General usage
 The library is header-only. Add the `src/dsmr_parser` folder to your project.<br>
-Note: [dlms_packet_decryptor.h](https://github.com/esphome-libs/dsmr_parser/blob/main/src/dsmr_parser/dlms_packet_decryptor.h) depends on [Mbed TLS](https://www.trustedfirmware.org/projects/mbed-tls/) library. It is already included in the `ESP-IDF` framework and can be easily added to any other platforms.
+Note: [dlms_packet_decryptor.h](https://github.com/esphome-libs/dsmr_parser/blob/main/src/dsmr_parser/dlms_packet_decryptor.h) depends on [Mbed TLS](https://www.trustedfirmware.org/projects/mbed-tls/) or [BearSsl](https://bearssl.org/) library. `Mbed TLS` is already included in the `ESP-IDF` framework and can be easily added to any other platforms.
 
 ## Usage from PlatformIO
 The library is available on the PlatformIO registry:<br>

--- a/src/dsmr_parser/aes128gcm.h
+++ b/src/dsmr_parser/aes128gcm.h
@@ -1,0 +1,47 @@
+#pragma once
+#include "util.h"
+#include <optional>
+
+namespace dsmr_parser {
+
+class Aes128GcmEncryptionKey final {
+  std::array<uint8_t, 16> key{};
+
+  Aes128GcmEncryptionKey() = default;
+
+public:
+  // key_hex is a string like "00112233445566778899AABBCCDDEEFF"
+  static std::optional<Aes128GcmEncryptionKey> from_hex(std::string_view key_hex) {
+    if (key_hex.size() != 32) {
+      return {};
+    }
+
+    Aes128GcmEncryptionKey res;
+
+    for (size_t i = 0; i < 16; ++i) {
+      const auto hi = to_hex_value(key_hex[2 * i]);
+      const auto lo = to_hex_value(key_hex[2 * i + 1]);
+      if (!hi || !lo) {
+        return {};
+      }
+      res.key[i] = static_cast<uint8_t>((*hi << 4) | *lo);
+    }
+
+    return res;
+  }
+
+  const uint8_t* data() const { return key.data(); }
+
+private:
+  static std::optional<uint8_t> to_hex_value(const char c) {
+    if (c >= '0' && c <= '9')
+      return static_cast<uint8_t>(c - '0');
+    if (c >= 'a' && c <= 'f')
+      return static_cast<uint8_t>(c - 'a' + 10);
+    if (c >= 'A' && c <= 'F')
+      return static_cast<uint8_t>(c - 'A' + 10);
+    return {};
+  }
+};
+
+}

--- a/src/dsmr_parser/aes128gcm_bearssl.h
+++ b/src/dsmr_parser/aes128gcm_bearssl.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "aes128gcm.h"
+#include "util.h"
+#include <bearssl.h>
+#include <span>
+
+namespace dsmr_parser {
+
+class Aes128GcmBearSsl final : NonCopyableAndNonMovable {
+  br_gcm_context gcm;
+  br_aes_ct_ctr_keys aes;
+  bool initialized = false;
+
+public:
+  Aes128GcmBearSsl() = default;
+
+  void set_encryption_key(const Aes128GcmEncryptionKey& key) {
+    br_aes_ct_ctr_init(&aes, key.data(), 16);
+    br_gcm_init(&gcm, &aes.vtable, br_ghash_ctmul32);
+    initialized = true;
+  }
+
+  bool decrypt_inplace(const std::array<const uint8_t, 17>& aad, const std::array<const uint8_t, 12>& nonce, std::span<uint8_t> ciphertext,
+                       const std::array<const uint8_t, 12>& tag) {
+    if (!initialized) {
+      return false;
+    }
+
+    br_gcm_reset(&gcm, nonce.data(), nonce.size());
+    br_gcm_aad_inject(&gcm, aad.data(), aad.size());
+    br_gcm_flip(&gcm);
+    br_gcm_run(&gcm, 0, ciphertext.data(), ciphertext.size());
+    return br_gcm_check_tag_trunc(&gcm, tag.data(), tag.size());
+  }
+
+  ~Aes128GcmBearSsl() = default;
+};
+
+}

--- a/src/dsmr_parser/aes128gcm_mbedtls.h
+++ b/src/dsmr_parser/aes128gcm_mbedtls.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "aes128gcm.h"
+#include "util.h"
+#include <mbedtls/gcm.h>
+#include <span>
+
+namespace dsmr_parser {
+
+class Aes128GcmMbedTls final : NonCopyableAndNonMovable {
+  mbedtls_gcm_context gcm;
+
+public:
+  Aes128GcmMbedTls() { mbedtls_gcm_init(&gcm); }
+
+  void set_encryption_key(const Aes128GcmEncryptionKey& key) { mbedtls_gcm_setkey(&gcm, MBEDTLS_CIPHER_ID_AES, key.data(), 128); }
+
+  bool decrypt_inplace(const std::array<const uint8_t, 17>& aad, const std::array<const uint8_t, 12>& nonce, std::span<uint8_t> ciphertext,
+                       const std::array<const uint8_t, 12>& tag) {
+    const auto& res = mbedtls_gcm_auth_decrypt(&gcm, ciphertext.size(), nonce.data(), nonce.size(), aad.data(), aad.size(), tag.data(), tag.size(),
+                                               ciphertext.data(), ciphertext.data());
+    return res == 0;
+  }
+
+  ~Aes128GcmMbedTls() { mbedtls_gcm_free(&gcm); }
+};
+
+}

--- a/src/dsmr_parser/dlms_packet_decryptor.h
+++ b/src/dsmr_parser/dlms_packet_decryptor.h
@@ -1,15 +1,17 @@
 #pragma once
+#include "aes128gcm.h"
 #include "util.h"
 #include <array>
-#include <mbedtls/gcm.h>
 #include <optional>
 #include <span>
+#include <string_view>
 #include <vector>
 
 namespace dsmr_parser {
 
 // Decrypts DLMS packets encrypted with AES-128-GCM.
 // The encryption is described in the "specs/Luxembourg Smarty P1 specification v1.1.3.pdf" chapter "3.2.5 P1 software – Channel security".
+template <typename Aes128Gcm>
 class DlmsPacketDecryptor final {
 
 #pragma pack(push, 1)
@@ -17,7 +19,7 @@ class DlmsPacketDecryptor final {
   //   Header (18 bytes) | Encrypted Telegram | GCM Tag (12 bytes)
   struct DlmsPacket final {
   private:
-    struct Header {
+    struct {
       uint8_t tag;                              // always = 0xDB
       uint8_t system_title_length;              // always = 0x08
       uint8_t system_title[8];                  // arbitrary sequence. For example: ['S', 'Y', 'S', 'T', 'E', 'M', 'I', 'D']
@@ -29,23 +31,38 @@ class DlmsPacketDecryptor final {
     uint8_t encrypted_telegram_with_gcm_tag[1]; // GCM Tag is 12 bytes
 
   public:
+    static DlmsPacket* from_bytes(const std::span<uint8_t> bytes) {
+      if (bytes.size() < sizeof(header) + /* tag length */ 12) {
+        return nullptr;
+      }
+
+      auto& packet = *reinterpret_cast<DlmsPacket*>(bytes.data());
+
+      const auto& length_correct = bytes.size() == sizeof(header) + /* tag length */ 12 + packet.telegram_length();
+      const auto& header_bytes_consistent = packet.header.tag == 0xDB && packet.header.system_title_length == 0x08 &&
+                                            packet.header.long_form_length_indicator == 0x82 && packet.header.security_control_field == 0x30;
+      if (!length_correct || !header_bytes_consistent) {
+        return nullptr;
+      }
+
+      return &packet;
+    }
+
     // Also called "IV"
-    auto nonce() const {
+    std::array<const uint8_t, 12> nonce() const {
       // nonce = SystemTitle (8 bytes) + InvocationCounter (4 bytes)
       const auto& st = header.system_title;
       const auto& ic = header.invocation_counter_big_endian;
-      return std::array<uint8_t, 12>{st[0], st[1], st[2], st[3], st[4], st[5], st[6], st[7], ic[0], ic[1], ic[2], ic[3]};
+      return {st[0], st[1], st[2], st[3], st[4], st[5], st[6], st[7], ic[0], ic[1], ic[2], ic[3]};
     }
 
-    std::span<const uint8_t> encrypted_telegram() const { return {encrypted_telegram_with_gcm_tag, telegram_length()}; }
-    std::span<const uint8_t> gcm_tag() const { return {encrypted_telegram_with_gcm_tag + telegram_length(), 12}; }
-
-    bool check_consistency(const size_t dlms_packet_length) const {
-      // Check the values of the constant fields and that the length is correct
-      return header.tag == 0xDB && header.system_title_length == 0x08 && header.long_form_length_indicator == 0x82 && header.security_control_field == 0x30 &&
-             dlms_packet_length == sizeof(Header) + /* gcm_tag length */ 12 + telegram_length();
+    std::span<uint8_t> encrypted_telegram() { return {encrypted_telegram_with_gcm_tag, telegram_length()}; }
+    std::array<const uint8_t, 12> gcm_tag() const {
+      const uint8_t* p = encrypted_telegram_with_gcm_tag + telegram_length();
+      return {p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], p[10], p[11]};
     }
 
+  private:
     // encrypted and decrypted telegrams have the same length
     size_t telegram_length() const {
       // Convert from big-endian to the host's little-endian
@@ -56,130 +73,29 @@ class DlmsPacketDecryptor final {
 #pragma pack(pop)
   static_assert(sizeof(DlmsPacket) == 19, "EncryptedPacket struct must be 19 bytes");
 
-  class MbedTlsAes128GcmDecryptor final : NonCopyableAndNonMovable {
-    mbedtls_gcm_context gcm;
-
-  public:
-    MbedTlsAes128GcmDecryptor() { mbedtls_gcm_init(&gcm); }
-
-    bool set_encryption_key(const std::span<const uint8_t> key) { return mbedtls_gcm_setkey(&gcm, MBEDTLS_CIPHER_ID_AES, key.data(), 128) == 0; }
-
-    bool decrypt(std::span<const uint8_t> iv, std::span<const uint8_t> ciphertext, std::span<const uint8_t> tag, std::span<char> decrypted_output_buffer) {
-      // aad = AdditionalAuthenticatedData = SecurityControlField + AuthenticationKey.
-      //   SecurityControlField is always 0x30.
-      //   AuthenticationKey = "00112233445566778899AABBCCDDEEFF". It is hardcoded and is the same for all DSMR devices.
-      constexpr uint8_t aad[] = {0x30, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
-
-      const auto& res = mbedtls_gcm_auth_decrypt(&gcm, ciphertext.size(), iv.data(), iv.size(), aad, std::size(aad), tag.data(), tag.size(), ciphertext.data(),
-                                                 reinterpret_cast<unsigned char*>(decrypted_output_buffer.data()));
-      return res == 0;
-    }
-
-    ~MbedTlsAes128GcmDecryptor() { mbedtls_gcm_free(&gcm); }
-  };
-
-  std::span<char> _decrypted_dsmr_telegram_buffer;
+  Aes128Gcm decryptor;
 
 public:
-  class EncryptionKey final {
-    friend DlmsPacketDecryptor;
+  void set_encryption_key(const Aes128GcmEncryptionKey& key) { decryptor.set_encryption_key(key); }
 
-    std::array<uint8_t, 16> key{};
-    EncryptionKey() = default;
-
-  public:
-    // key_hex is a string like "00112233445566778899AABBCCDDEEFF"
-    static std::optional<EncryptionKey> FromHex(std::string_view key_hex) {
-      if (key_hex.size() != 32) {
-        return {};
-      }
-
-      EncryptionKey res;
-
-      for (size_t i = 0; i < 16; ++i) {
-        const auto hi = to_hex_value(key_hex[2 * i]);
-        const auto lo = to_hex_value(key_hex[2 * i + 1]);
-        if (!hi || !lo) {
-          return {};
-        }
-        res.key[i] = static_cast<uint8_t>((*hi << 4) | *lo);
-      }
-
-      return res;
-    }
-
-  private:
-    static std::optional<uint8_t> to_hex_value(const char c) {
-      if (c >= '0' && c <= '9')
-        return static_cast<uint8_t>(c - '0');
-      if (c >= 'a' && c <= 'f')
-        return static_cast<uint8_t>(c - 'a' + 10);
-      if (c >= 'A' && c <= 'F')
-        return static_cast<uint8_t>(c - 'A' + 10);
+  std::optional<std::string_view> decrypt_inplace(std::span<uint8_t> dlms_packet_bytes) {
+    auto dlms_packet = DlmsPacket::from_bytes(dlms_packet_bytes);
+    if (dlms_packet == nullptr) {
       return {};
     }
-  };
 
-  enum class Error { EncryptedTelegramIsTooSmall, DecryptedTelegramBufferIsTooSmall, HeaderCorrupted, FailedToSetEncryptionKey, DecryptionFailed };
+    // aad = AdditionalAuthenticatedData = SecurityControlField + AuthenticationKey.
+    //   SecurityControlField is always 0x30.
+    //   AuthenticationKey = "00112233445566778899AABBCCDDEEFF". It is hardcoded and is the same for all DSMR devices.
+    constexpr std::array<const uint8_t, 17> aad{0x30, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
 
-  class Result final {
-    friend DlmsPacketDecryptor;
-
-    std::optional<std::string_view> _dsmr_telegram;
-    std::optional<Error> _error;
-
-    Result() = default;
-    Result(std::string_view dsmr_telegram) : _dsmr_telegram(dsmr_telegram) {}
-    Result(Error error) : _error(error) {}
-
-  public:
-    auto dsmr_telegram() const { return _dsmr_telegram; }
-    auto error() const { return _error; }
-  };
-
-  explicit DlmsPacketDecryptor(std::span<char> decrypted_dsmr_telegram_buffer) : _decrypted_dsmr_telegram_buffer(decrypted_dsmr_telegram_buffer) {}
-
-  Result decrypt(std::span<const uint8_t> dlms_packet_bytes, const EncryptionKey& encryption_key) const {
-    if (dlms_packet_bytes.size() < sizeof(DlmsPacket)) {
-      return Error::EncryptedTelegramIsTooSmall;
+    const bool res = decryptor.decrypt_inplace(aad, dlms_packet->nonce(), dlms_packet->encrypted_telegram(), dlms_packet->gcm_tag());
+    if (!res) {
+      return {};
     }
 
-    const auto& dlms_packet = *reinterpret_cast<const DlmsPacket*>(dlms_packet_bytes.data());
-    if (!dlms_packet.check_consistency(dlms_packet_bytes.size())) {
-      return Error::HeaderCorrupted;
-    }
-
-    if (_decrypted_dsmr_telegram_buffer.size() < dlms_packet.encrypted_telegram().size())
-      return Error::DecryptedTelegramBufferIsTooSmall;
-
-    MbedTlsAes128GcmDecryptor decryptor;
-
-    if (!decryptor.set_encryption_key(encryption_key.key)) {
-      return Error::FailedToSetEncryptionKey;
-    }
-
-    if (!decryptor.decrypt(dlms_packet.nonce(), dlms_packet.encrypted_telegram(), dlms_packet.gcm_tag(), _decrypted_dsmr_telegram_buffer)) {
-      return Error::DecryptionFailed;
-    }
-
-    return std::string_view(_decrypted_dsmr_telegram_buffer.data(), dlms_packet.telegram_length());
+    return std::string_view{reinterpret_cast<const char*>(dlms_packet->encrypted_telegram().data()), dlms_packet->encrypted_telegram().size()};
   }
 };
-
-inline const char* to_string(const DlmsPacketDecryptor::Error error) {
-  switch (error) {
-  case DlmsPacketDecryptor::Error::EncryptedTelegramIsTooSmall:
-    return "EncryptedTelegramIsTooSmall";
-  case DlmsPacketDecryptor::Error::DecryptedTelegramBufferIsTooSmall:
-    return "DecryptedTelegramBufferIsTooSmall";
-  case DlmsPacketDecryptor::Error::HeaderCorrupted:
-    return "HeaderCorrupted";
-  case DlmsPacketDecryptor::Error::FailedToSetEncryptionKey:
-    return "FailedToSetEncryptionKey";
-  case DlmsPacketDecryptor::Error::DecryptionFailed:
-    return "DecryptionFailed";
-  }
-  return "Unknown error";
-}
 
 }

--- a/src/dsmr_parser/fields.h
+++ b/src/dsmr_parser/fields.h
@@ -260,14 +260,14 @@ const uint8_t WATER_MBUS_ID = DSMR_WATER_MBUS_ID;
 const uint8_t THERMAL_MBUS_ID = DSMR_THERMAL_MBUS_ID;
 const uint8_t SUB_MBUS_ID = DSMR_SUB_MBUS_ID;
 
-#define DEFINE_FIELD(fieldname, value_t, obis, field_t, ...) \
-  struct fieldname : field_t<fieldname, ##__VA_ARGS__> {     \
-    value_t fieldname;                                       \
-    bool fieldname##_present = false;                        \
-    static inline constexpr ObisId id = obis;                \
-    static inline constexpr char name[] = #fieldname;        \
-    value_t& val() { return fieldname; }                     \
-    bool& present() { return fieldname##_present; }          \
+#define DEFINE_FIELD(fieldname, value_t, obis, field_t, ...)         \
+  struct fieldname : field_t<fieldname __VA_OPT__(, __VA_ARGS__)> {  \
+    value_t fieldname;                                               \
+    bool fieldname##_present = false;                                \
+    static inline constexpr ObisId id = obis;                        \
+    static inline constexpr char name[] = #fieldname;                \
+    value_t& val() { return fieldname; }                             \
+    bool& present() { return fieldname##_present; }                  \
   }
 
 // Meter identification. This is not a normal field, but a specially-formatted first line of the message

--- a/src/dsmr_parser/packet_accumulator.h
+++ b/src/dsmr_parser/packet_accumulator.h
@@ -2,8 +2,8 @@
 #include "util.h"
 #include <cstdint>
 #include <optional>
-#include <string_view>
 #include <span>
+#include <string_view>
 
 namespace dsmr_parser {
 

--- a/src/test/aes128gcm_bearssl_include_test.cpp
+++ b/src/test/aes128gcm_bearssl_include_test.cpp
@@ -1,0 +1,12 @@
+// This code tests that the header has all necessary dependencies included in its headers.
+// We check that the code compiles.
+
+#include "dsmr_parser/aes128gcm_bearssl.h"
+
+using namespace dsmr_parser;
+
+void Aes128GcmBearssl_some_function() {
+  Aes128GcmBearSsl aes;
+  const auto& key = Aes128GcmEncryptionKey::from_hex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  aes.set_encryption_key(*key);
+}

--- a/src/test/aes128gcm_mbedtls_include_test.cpp
+++ b/src/test/aes128gcm_mbedtls_include_test.cpp
@@ -1,0 +1,12 @@
+// This code tests that the header has all necessary dependencies included in its headers.
+// We check that the code compiles.
+
+#include "dsmr_parser/aes128gcm_mbedtls.h"
+
+using namespace dsmr_parser;
+
+void Aes128GcmMbedtls_some_function() {
+  Aes128GcmMbedTls aes;
+  const auto& key = Aes128GcmEncryptionKey::from_hex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  aes.set_encryption_key(*key);
+}

--- a/src/test/dlms_packet_decryptor_include_test.cpp
+++ b/src/test/dlms_packet_decryptor_include_test.cpp
@@ -1,12 +1,15 @@
 // This code tests that the encrypted_packet_accumulator header has all necessary dependencies included in its headers.
 // We check that the code compiles.
 
+#include "dsmr_parser/aes128gcm_mbedtls.h"
 #include "dsmr_parser/dlms_packet_decryptor.h"
 
-std::array<uint8_t, 1000> encrypted_packet_buffer;
-std::array<char, 1000> decrypted_packet_buffer;
-const auto encryption_key = *dsmr_parser::DlmsPacketDecryptor::EncryptionKey::FromHex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+using namespace dsmr_parser;
+
 void DlmsPacketDecryptor_some_function() {
-  const auto& decryptor = dsmr_parser::DlmsPacketDecryptor(decrypted_packet_buffer);
-  decryptor.decrypt(encrypted_packet_buffer, encryption_key);
+  std::array<uint8_t, 1000> packet_buffer;
+  const auto encryption_key = *Aes128GcmEncryptionKey::from_hex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  DlmsPacketDecryptor<Aes128GcmMbedTls> decryptor;
+  decryptor.set_encryption_key(encryption_key);
+  decryptor.decrypt_inplace(packet_buffer);
 }

--- a/src/test/dlms_packet_decryptor_test.cpp
+++ b/src/test/dlms_packet_decryptor_test.cpp
@@ -1,3 +1,5 @@
+#include "dsmr_parser/aes128gcm_bearssl.h"
+#include "dsmr_parser/aes128gcm_mbedtls.h"
 #include "dsmr_parser/dlms_packet_decryptor.h"
 #include <doctest.h>
 #include <filesystem>
@@ -12,85 +14,98 @@ inline std::vector<std::uint8_t> read_binary_file(const std::filesystem::path& p
   return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
 }
 
-const auto& dlms_packet =
-    read_binary_file(std::filesystem::path(std::source_location::current().file_name()).parent_path() / "test_data" / "encrypted_packet.bin");
+inline std::vector<std::uint8_t> get_test_encrypted_packet() {
+  return read_binary_file(std::filesystem::path(std::source_location::current().file_name()).parent_path() / "test_data" / "encrypted_packet.bin");
+}
 
 TEST_CASE("EncryptionKey FromHex method works correctly") {
   // success cases
-  REQUIRE(DlmsPacketDecryptor::EncryptionKey::FromHex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
-  REQUIRE(DlmsPacketDecryptor::EncryptionKey::FromHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+  REQUIRE(Aes128GcmEncryptionKey::from_hex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+  REQUIRE(Aes128GcmEncryptionKey::from_hex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
 
   // failure cases
-  REQUIRE(!DlmsPacketDecryptor::EncryptionKey::FromHex("AAAAAAAAAAA"));                      // key too short
-  REQUIRE(!DlmsPacketDecryptor::EncryptionKey::FromHex("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")); // non hex symbols in key
+  REQUIRE(!Aes128GcmEncryptionKey::from_hex("AAAAAAAAAAA"));                      // key too short
+  REQUIRE(!Aes128GcmEncryptionKey::from_hex("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")); // non hex symbols in key
 }
 
 TEST_CASE("Can decrypt a correct packet") {
-  std::array<char, 2000> decrypted_dsmr_telegram_buffer{};
-  auto decryptor = DlmsPacketDecryptor(decrypted_dsmr_telegram_buffer);
-  const auto encryption_key = *DlmsPacketDecryptor::EncryptionKey::FromHex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  const auto encryption_key = *Aes128GcmEncryptionKey::from_hex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  const auto packet_starts = std::string_view{"/EST5\\253710000_A\r\n"};
+  const auto packet_ends = std::string_view{"1-0:4.7.0(000000166*var)\r\n!7EF9\r\n"};
 
-  const auto& res = decryptor.decrypt(dlms_packet, encryption_key);
-  REQUIRE(!res.error());
+  SUBCASE("MbedTls") {
+    DlmsPacketDecryptor<Aes128GcmMbedTls> decryptor;
+    decryptor.set_encryption_key(encryption_key);
+    auto packet = get_test_encrypted_packet();
 
-  const auto dsmr_telegram = std::string(*res.dsmr_telegram());
-  REQUIRE(dsmr_telegram.ends_with("1-0:4.7.0(000000166*var)\r\n!7EF9\r\n"));
-  REQUIRE(dsmr_telegram.starts_with("/EST5\\253710000_A\r\n"));
+    const auto dsmr_telegram = decryptor.decrypt_inplace({packet.data(), packet.size()});
+    REQUIRE(dsmr_telegram);
+    REQUIRE(dsmr_telegram->starts_with(packet_starts));
+    REQUIRE(dsmr_telegram->ends_with(packet_ends));
+  }
+
+  SUBCASE("BearSsl") {
+    DlmsPacketDecryptor<Aes128GcmBearSsl> decryptor;
+    decryptor.set_encryption_key(encryption_key);
+    auto packet = get_test_encrypted_packet();
+
+    const auto dsmr_telegram = decryptor.decrypt_inplace({packet.data(), packet.size()});
+    REQUIRE(dsmr_telegram);
+    REQUIRE(dsmr_telegram->starts_with(packet_starts));
+    REQUIRE(dsmr_telegram->ends_with(packet_ends));
+  }
 }
 
 TEST_CASE("Fail to decrypt corrupted packet") {
-  std::array<char, 2000> decrypted_dsmr_telegram_buffer{};
-  auto decryptor = DlmsPacketDecryptor(decrypted_dsmr_telegram_buffer);
-  const auto encryption_key = *DlmsPacketDecryptor::EncryptionKey::FromHex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  const auto encryption_key = *Aes128GcmEncryptionKey::from_hex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  auto packet = get_test_encrypted_packet();
+  packet[50] ^= 0xFF;
 
-  auto corrupted_packet = dlms_packet;
-  corrupted_packet[50] ^= 0xFF;
+  SUBCASE("MbedTls") {
+    DlmsPacketDecryptor<Aes128GcmMbedTls> decryptor;
+    decryptor.set_encryption_key(encryption_key);
+    REQUIRE_FALSE(decryptor.decrypt_inplace({packet.data(), packet.size()}));
+  }
 
-  const auto& res = decryptor.decrypt(corrupted_packet, encryption_key);
-  REQUIRE(res.error());
-  REQUIRE(*res.error() == DlmsPacketDecryptor::Error::DecryptionFailed);
+  SUBCASE("BearSsl") {
+    DlmsPacketDecryptor<Aes128GcmBearSsl> decryptor;
+    decryptor.set_encryption_key(encryption_key);
+    REQUIRE_FALSE(decryptor.decrypt_inplace({packet.data(), packet.size()}));
+  }
 }
 
 TEST_CASE("Fail to decrypt packet with corrupted header") {
-  std::array<char, 2000> decrypted_dsmr_telegram_buffer{};
-  auto decryptor = DlmsPacketDecryptor(decrypted_dsmr_telegram_buffer);
-  const auto encryption_key = *DlmsPacketDecryptor::EncryptionKey::FromHex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  DlmsPacketDecryptor<Aes128GcmMbedTls> decryptor;
+  const auto encryption_key = *Aes128GcmEncryptionKey::from_hex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  auto packet = get_test_encrypted_packet();
+  decryptor.set_encryption_key(encryption_key);
 
-  auto corrupted_packet = dlms_packet;
-  corrupted_packet[0] = 0;
+  packet[0] = 0;
 
-  const auto& res = decryptor.decrypt(corrupted_packet, encryption_key);
-  REQUIRE(res.error());
-  REQUIRE(*res.error() == DlmsPacketDecryptor::Error::HeaderCorrupted);
+  const auto dsmr_telegram = decryptor.decrypt_inplace({packet.data(), packet.size()});
+  REQUIRE_FALSE(dsmr_telegram);
 }
 
-TEST_CASE("Decription fails because specified length in dlms packet is smaller than the received data") {
-  std::array<char, 2000> decrypted_dsmr_telegram_buffer{};
-  auto decryptor = DlmsPacketDecryptor(decrypted_dsmr_telegram_buffer);
-  const auto encryption_key = *DlmsPacketDecryptor::EncryptionKey::FromHex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-
-  const auto& res = decryptor.decrypt({dlms_packet.data(), dlms_packet.size() - 1}, encryption_key);
-  REQUIRE(res.error());
-  REQUIRE(*res.error() == DlmsPacketDecryptor::Error::HeaderCorrupted);
-}
-
-TEST_CASE("Decription fails if the dlms packet is too small") {
-  std::array<char, 2000> decrypted_dsmr_telegram_buffer{};
-  auto decryptor = DlmsPacketDecryptor(decrypted_dsmr_telegram_buffer);
-  const auto encryption_key = *DlmsPacketDecryptor::EncryptionKey::FromHex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-
+TEST_CASE("Decryption fails if the dlms packet is too small") {
+  DlmsPacketDecryptor<Aes128GcmMbedTls> decryptor;
+  const auto encryption_key = *Aes128GcmEncryptionKey::from_hex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
   std::vector<uint8_t> small_dlms_packet(10);
-  const auto& res = decryptor.decrypt(small_dlms_packet, encryption_key);
-  REQUIRE(res.error());
-  REQUIRE(*res.error() == DlmsPacketDecryptor::Error::EncryptedTelegramIsTooSmall);
+  decryptor.set_encryption_key(encryption_key);
+
+  const auto dsmr_telegram = decryptor.decrypt_inplace({small_dlms_packet.data(), small_dlms_packet.size()});
+  REQUIRE_FALSE(dsmr_telegram);
 }
 
-TEST_CASE("Decription fails if the decryption buffer is too small") {
-  std::array<char, 10> decrypted_dsmr_telegram_buffer{};
-  auto decryptor = DlmsPacketDecryptor(decrypted_dsmr_telegram_buffer);
-  const auto encryption_key = *DlmsPacketDecryptor::EncryptionKey::FromHex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+TEST_CASE("Does not crash if decrypt_inplace is called without set_encryption_key") {
+  auto packet = get_test_encrypted_packet();
 
-  const auto& res = decryptor.decrypt(dlms_packet, encryption_key);
-  REQUIRE(res.error());
-  REQUIRE(*res.error() == DlmsPacketDecryptor::Error::DecryptedTelegramBufferIsTooSmall);
+  SUBCASE("MbedTls") {
+    DlmsPacketDecryptor<Aes128GcmMbedTls> decryptor;
+    REQUIRE_FALSE(decryptor.decrypt_inplace({packet.data(), packet.size()}));
+  }
+
+  SUBCASE("BearSsl") {
+    DlmsPacketDecryptor<Aes128GcmBearSsl> decryptor;
+    REQUIRE_FALSE(decryptor.decrypt_inplace({packet.data(), packet.size()}));
+  }
 }


### PR DESCRIPTION
Some embedded SDKs contain only BearSsl. For example, `esp8266`.

Changes:
* Added an optional decryption implementation using `BearSsl`.
* The decryption is done in place. It saves memory.

This pull request doesn't change any code that is used anywhere.