### PR TITLE
Add files needed to create ESP-IDF component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build/
 /out/
+/dist/
 .idea/
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
-cmake_minimum_required (VERSION 3.20)
-project(arduino-dsmr-test LANGUAGES CXX C)
+if(ESP_PLATFORM)
+   idf_component_register(INCLUDE_DIRS "src") # header-only
+   return()
+endif()
+
+cmake_minimum_required(VERSION 3.20)
+project(dsmr_parser)
 include(FetchContent)
 
 # doctest
@@ -34,21 +39,21 @@ FetchContent_Populate(
 include(${cmake_template_SOURCE_DIR}/cmake/CompilerWarnings.cmake)
 include(${cmake_template_SOURCE_DIR}/cmake/Sanitizers.cmake)
 
-# arduino_dsmr_test
-file(GLOB_RECURSE arduino_dsmr_test_src_files CONFIGURE_DEPENDS "src/*.h" "src/*.cpp")
-add_executable(arduino_dsmr_test ${arduino_dsmr_test_src_files})
-target_include_directories(arduino_dsmr_test PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/doctest)
-target_compile_features(arduino_dsmr_test PRIVATE cxx_std_20)
-target_link_libraries(arduino_dsmr_test PRIVATE mbedtls bearssl)
-target_include_directories(arduino_dsmr_test SYSTEM PUBLIC $<TARGET_PROPERTY:mbedtls,INTERFACE_INCLUDE_DIRECTORIES>) # disable warnings for mbedtls headers
-target_compile_options(arduino_dsmr_test PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/Zc:preprocessor>) # enable __VA_OPT__ on MSVC
+# dsmr_parser_test
+file(GLOB_RECURSE dsmr_parser_test_src_files CONFIGURE_DEPENDS "src/*.h" "src/*.cpp")
+add_executable(dsmr_parser_test ${dsmr_parser_test_src_files})
+target_include_directories(dsmr_parser_test PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/doctest)
+target_compile_features(dsmr_parser_test PRIVATE cxx_std_20)
+target_link_libraries(dsmr_parser_test PRIVATE mbedtls bearssl)
+target_include_directories(dsmr_parser_test SYSTEM PUBLIC $<TARGET_PROPERTY:mbedtls,INTERFACE_INCLUDE_DIRECTORIES>) # disable warnings for mbedtls headers
+target_compile_options(dsmr_parser_test PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/Zc:preprocessor>) # enable __VA_OPT__ on MSVC
 
 # enable warnings
-add_library(arduino_dsmr_test_warnings INTERFACE)
-myproject_set_project_warnings(arduino_dsmr_test_warnings ON "" "" "" "")
-target_link_libraries(arduino_dsmr_test PRIVATE arduino_dsmr_test_warnings)
+add_library(dsmr_parser_test_warnings INTERFACE)
+myproject_set_project_warnings(dsmr_parser_test_warnings ON "" "" "" "")
+target_link_libraries(dsmr_parser_test PRIVATE dsmr_parser_test_warnings)
 
 # enable sanitizers: address, leak, undefined behaviour
-add_library(arduino_dsmr_test_sanitizers INTERFACE)
-myproject_enable_sanitizers(arduino_dsmr_test_sanitizers ON ON ON OFF OFF)
-target_link_libraries(arduino_dsmr_test PRIVATE arduino_dsmr_test_sanitizers)
+add_library(dsmr_parser_test_sanitizers INTERFACE)
+myproject_enable_sanitizers(dsmr_parser_test_sanitizers ON ON ON OFF OFF)
+target_link_libraries(dsmr_parser_test PRIVATE dsmr_parser_test_sanitizers)

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -17,7 +17,7 @@ build_and_test() {
         -G "Ninja" \
         -D CMAKE_BUILD_TYPE="$build_type"
   cmake --build "$buildDir/${target}-$build_type"
-  "$buildDir/${target}-$build_type/arduino_dsmr_test"
+  "$buildDir/${target}-$build_type/dsmr_parser_test"
 }
 
 build_and_test Debug linux-gcc

--- a/build-win.ps1
+++ b/build-win.ps1
@@ -31,7 +31,7 @@ Function BuildAndTest($buildType, $arch) {
   CheckReturnCodeOfPreviousCommand "cmake build failed"
 
   Info "Run tests"
-  & "$thisBuildDir/arduino_dsmr_test.exe"
+  & "$thisBuildDir/dsmr_parser_test.exe"
   CheckReturnCodeOfPreviousCommand "tests failed"
 }
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,11 @@
+description: "A parser for Dutch Smart Meter Requirements (DSMR) telegrams. Fork of arduino-dsmr. Doesn't depend on the Arduino framework and has many bug fixes and code quality improvements. Supports encrypted DSMR packets"
+url: "https://github.com/esphome-libs/dsmr_parser"
+repository: "https://github.com/esphome-libs/dsmr_parser.git"
+files:
+  exclude:
+    - "**/*"
+  include:
+    - src/dsmr_parser/*.h
+    - LICENSE
+    - README.md
+    - CMakeLists.txt

--- a/library.json
+++ b/library.json
@@ -1,12 +1,16 @@
 {
   "name": "dsmr_parser",
-  "version": "1.0",
-  "description": "Fork of arduino-dsmr. Doesn't depend on the Arduino framework and has many bug fixes and code quality improvements. Supports encrypted DSMR packets.",
+  "version": "1.0.0",
+  "description": "A parser for Dutch Smart Meter Requirements (DSMR) telegrams. Fork of arduino-dsmr. Doesn't depend on the Arduino framework and has many bug fixes and code quality improvements. Supports encrypted DSMR packets.",
   "keywords": "dsmr",
   "repository": {
     "type": "git",
-    "url": "https://github.com/esphome-libs/arduino-dsmr"
+    "url": "https://github.com/esphome-libs/dsmr_parser"
   },
   "license": "MIT",
-  "export": { "include": [ "src/dsmr_parser/*.h" ] }
+  "export": {
+    "include": [
+      "src/dsmr_parser/*.h"
+    ]
+  }
 }


### PR DESCRIPTION
`idf_component_register(INCLUDE_DIRS "src")`
The dummy source file is not needed ([example from esp-idf repo](https://github.com/espressif/esp-idf/blob/ff97953b32a32e44f507593320b50d728eea3f06/components/esp_driver_spi/test_apps/components/spi_bench_mark/CMakeLists.txt))