### PR TITLE
Properly parse lines like "1-0:0.2.0((ER11))".

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "dsmr_parser",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A parser for Dutch Smart Meter Requirements (DSMR) telegrams. Fork of arduino-dsmr. Doesn't depend on the Arduino framework and has many bug fixes and code quality improvements. Supports encrypted DSMR packets.",
   "keywords": "dsmr",
   "repository": {

--- a/src/dsmr_parser/fields.h
+++ b/src/dsmr_parser/fields.h
@@ -566,11 +566,11 @@ DEFINE_FIELD(active_energy_import_maximum_demand_running_month, TimestampedFixed
 DEFINE_FIELD(active_energy_import_maximum_demand_last_13_months, FixedValue, ObisId(0, 0, 98, 1, 0), AveragedFixedField, units::kW, units::W);
 
 // Image Core Version and checksum
-DEFINE_FIELD(fw_core_version, FixedValue, ObisId(1, 0, 0, 2, 0), FixedField, units::none, units::none);
-DEFINE_FIELD(fw_core_checksum, std::string, ObisId(1, 0, 0, 2, 8), StringField, 0, 8);
+DEFINE_FIELD(fw_core_version, std::string, ObisId(1, 0, 0, 2, 0), StringField, 0, 96);
+DEFINE_FIELD(fw_core_checksum, std::string, ObisId(1, 0, 0, 2, 8), StringField, 0, 96);
 // Image Module Version and checksum
-DEFINE_FIELD(fw_module_version, FixedValue, ObisId(1, 1, 0, 2, 0), FixedField, units::none, units::none);
-DEFINE_FIELD(fw_module_checksum, std::string, ObisId(1, 1, 0, 2, 8), StringField, 0, 8);
+DEFINE_FIELD(fw_module_version, std::string, ObisId(1, 1, 0, 2, 0), StringField, 0, 96);
+DEFINE_FIELD(fw_module_checksum, std::string, ObisId(1, 1, 0, 2, 8), StringField, 0, 96);
 
 }
 }

--- a/src/dsmr_parser/parser.h
+++ b/src/dsmr_parser/parser.h
@@ -83,6 +83,11 @@ struct StringParser final {
     while (str_end < end && *str_end != ')')
       ++str_end;
 
+    // We can have )) at the end. Thus we should add the first ) to the string.
+    // Like in the situation when we parse "((ER11))".
+    if (str_end + 1 < end && *(str_end + 1) == ')')
+      ++str_end;
+
     if (str_end == end)
       return res.fail("Missing )", str_end);
 
@@ -367,9 +372,20 @@ public:
     // We need to track brackets to handle cases like:
     //   0-0:96.13.0(303132333435
     //   30313233343)
+    // Also we need to handle cases like:
+    //   1-0:0.2.0((ER11))
     bool open_bracket_found = false;
     while (line_end < end) {
       char c = *line_end;
+      char next_c = (line_end + 1 < end) ? *(line_end + 1) : '\0';
+
+      if ((c == '(' && next_c == '(') || (c == ')' && next_c == ')')) {
+        // we have a case like:
+        //   1-0:0.2.0((ER11))
+        // Treat double brackets as a single bracket for bracket tracking
+        line_end++;
+        c = next_c;
+      }
 
       if (c == '(') {
         if (open_bracket_found) {

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -44,8 +44,12 @@ TEST_CASE("Should parse all fields in the DSMR message correctly") {
                     "0-1:24.1.0(003)\r\n"
                     "0-1:96.1.0(0000000000000000000000000000000000)\r\n"
                     "0-1:24.2.1(150117180000W)(00473.789*m3)\r\n"
+                    "1-0:0.2.0((ER11))\r\n"
+                    "1-0:0.2.8(1.0.smth smth-123)\r\n"
+                    "1-1:0.2.0((ER12)\r\n"
+                    "1-1:0.2.8(ER13))\r\n"
                     "0-1:24.4.0(1)\r\n"
-                    "!f2C9\r\n";
+                    "!96c9\r\n";
 
   ParsedData<
       /* String */ identification,
@@ -96,7 +100,11 @@ TEST_CASE("Should parse all fields in the DSMR message correctly") {
       /* String */ water_equipment_id,
       /* uint8_t */ water_valve_position,
       /* TimestampedFixedValue */ water_delivered,
-      /* AveragedFixedField */ active_energy_import_maximum_demand_last_13_months>
+      /* AveragedFixedField */ active_energy_import_maximum_demand_last_13_months,
+      /* String */ fw_core_version,
+      /* String */ fw_core_checksum,
+      /* String */ fw_module_version,
+      /* String */ fw_module_checksum>
       data;
 
   auto res = P1Parser::parse(data, msg, std::size(msg), true);
@@ -134,6 +142,10 @@ TEST_CASE("Should parse all fields in the DSMR message correctly") {
   REQUIRE(data.gas_valve_position == 1);
   REQUIRE(data.gas_delivered == 473.789f);
   REQUIRE(data.active_energy_import_maximum_demand_last_13_months.val() == 4.429f);
+  REQUIRE(data.fw_core_version == "(ER11)");
+  REQUIRE(data.fw_core_checksum == "1.0.smth smth-123");
+  REQUIRE(data.fw_module_version == "(ER12");
+  REQUIRE(data.fw_module_checksum == "ER13)");
 }
 
 TEST_CASE("Should report an error if the crc has incorrect format") {


### PR DESCRIPTION
Fix issue [[dsmr] 2026.1.3 no longer works and prints out Unexpected '(' symbol repeatidly](https://github.com/esphome/esphome/issues/13751).
The smart meter `ISk5\\2M550T-2006` output contains the line `1-0:0.2.0((ER11))`. This causes the parser to fail with the error `Unexpected '(' symbol`.

Changes:
* The parser properly handles this case.
* Change fw version fields to strings instead on integer. Because a version can be an arbitrary string.
* Increase the version to `1.1.0`