### PR TITLE
electricity_switch_position field should be a string

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "dsmr_parser",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A parser for Dutch Smart Meter Requirements (DSMR) telegrams. Fork of arduino-dsmr. Doesn't depend on the Arduino framework and has many bug fixes and code quality improvements. Supports encrypted DSMR packets.",
   "keywords": "dsmr",
   "repository": {

--- a/src/dsmr_parser/fields.h
+++ b/src/dsmr_parser/fields.h
@@ -340,7 +340,7 @@ DEFINE_FIELD(power_returned_ch, FixedValue, ObisId(1, 1, 2, 7, 0), FixedField, u
 DEFINE_FIELD(electricity_threshold, FixedValue, ObisId(0, 0, 17, 0, 0), FixedField, units::kW, units::W);
 
 // Switch position Electricity (in/out/enabled). Removed in 4.0.7 / 4.2.2 / 5.0
-DEFINE_FIELD(electricity_switch_position, uint8_t, ObisId(0, 0, 96, 3, 10), IntField, units::none);
+DEFINE_FIELD(electricity_switch_position, std::string_view, ObisId(0, 0, 96, 3, 10), StringField, 1, 32);
 
 // Number of power failures in any phase
 DEFINE_FIELD(electricity_failures, uint32_t, ObisId(0, 0, 96, 7, 21), IntField, units::none);

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -28,7 +28,7 @@ TEST_CASE_FIXTURE(LogFixture, "Should parse all fields in the DSMR message corre
                     "1-0:1.7.0(00.333*kW)\r\n"
                     "1-0:2.7.0(00.000*kW)\r\n"
                     "0-0:17.0.0(999.9*kW)\r\n"
-                    "0-0:96.3.10(1)\r\n"
+                    "0-0:96.3.10(on)\r\n"
                     "0-0:96.7.21(00008)\r\n"
                     "0-0:96.7.9(00007)\r\n"
                     "1-0:99.97.0(1)(0-0:96.7.19)(000101000001W)(2147483647*s)\r\n"
@@ -87,7 +87,7 @@ TEST_CASE_FIXTURE(LogFixture, "Should parse all fields in the DSMR message corre
       /* FixedValue */ power_delivered,
       /* FixedValue */ power_returned,
       /* FixedValue */ electricity_threshold,
-      /* uint8_t */ electricity_switch_position,
+      /* String */ electricity_switch_position,
       /* uint32_t */ electricity_failures,
       /* uint32_t */ electricity_long_failures,
       /* String */ electricity_failure_log,
@@ -161,7 +161,7 @@ TEST_CASE_FIXTURE(LogFixture, "Should parse all fields in the DSMR message corre
   REQUIRE(data.power_delivered == 0.333f);
   REQUIRE(data.power_returned == 0.0f);
   REQUIRE(data.electricity_threshold == 999.9f);
-  REQUIRE(data.electricity_switch_position == 1);
+  REQUIRE(data.electricity_switch_position == "on");
   REQUIRE(data.electricity_failures == 8);
   REQUIRE(data.electricity_long_failures == 7);
   REQUIRE(data.electricity_failure_log == "(1)(0-0:96.7.19)(000101000001W)(2147483647*s)");


### PR DESCRIPTION
Meters in Hungary use a string value to indicate the switch position, like `0-0:96.3.10(ON)`:
https://github.com/esphome-libs/dsmr_parser/issues/53