### PR TITLE
Add a HexStringField parser which understands some DSMRs encode the equipement ids as hex strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ The primary goal is to make the parser independent of the Arduino framework and 
 * Combines all fixes from [matthijskooijman/arduino-dsmr](https://github.com/matthijskooijman/arduino-dsmr) and [glmnet/arduino-dsmr](https://github.com/glmnet/arduino-dsmr) including unmerged pull requests.
 * Added an extensive unit test suite
 * Code optimizations
-* No dynamic memory allocations
 * Supported compilers: MSVC, GCC, Clang
 * Header-only library, no dependencies
 * Code can be used on any platform, not only embedded

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "dsmr_parser",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "A parser for Dutch Smart Meter Requirements (DSMR) telegrams. Fork of arduino-dsmr. Doesn't depend on the Arduino framework and has many bug fixes and code quality improvements. Supports encrypted DSMR packets.",
   "keywords": "dsmr",
   "repository": {

--- a/src/dsmr_parser/fields.h
+++ b/src/dsmr_parser/fields.h
@@ -3,6 +3,8 @@
 #include "parser.h"
 #include "util.h"
 #include <optional>
+#include <algorithm>
+#include <string>
 #include <string_view>
 
 #ifndef DSMR_GAS_MBUS_ID
@@ -38,6 +40,46 @@ struct StringField : ParsedField<T> {
       static_cast<T*>(this)->val() = sv;
     return res;
   }
+};
+
+// A hexstring field is essencially a string filled with hex digits. If the
+// string does not consist of an even number of hex digits, the original
+// string is returned, otherwise the decoded hex string is returned.
+template <typename T, size_t minlen, size_t maxlen>
+struct HexStringField : ParsedField<T> {
+  std::optional<std::string_view> parse(std::string_view input) {
+    std::string_view sv;
+    auto res = parse_string(sv, minlen, maxlen, input);
+    if (res) {
+      static_cast<T*>(this)->val() = sv;
+
+      if (sv.length() & 1) {
+        // Odd number of chars, can't be a hex coded string.
+        return res;
+      }
+      if (!std::all_of(sv.begin(), sv.end(), [](unsigned char ch){ return isxdigit(ch); })) {
+        // Not all chars are hex digits.
+        return res;
+      }
+      hexStr.clear();
+      hexStr.reserve(sv.length()/2);
+      for (auto it = sv.begin(); it != sv.end(); ++it) {
+        const int ch1 = *it++;
+        const int ch2 = *it;
+        auto val = (isdigit(ch1) ? ch1 - '0' : toupper(ch1) - 'A' + 10) * 16 +
+                   (isdigit(ch2) ? ch2 - '0' : toupper(ch2) - 'A' + 10);
+	if (val < 0x20 || val > 0x7E) {
+          // Not visible ascii.
+          return res;
+        }
+        hexStr.push_back(static_cast<char>(val));
+      }
+      static_cast<T*>(this)->val() = std::string_view(hexStr);
+    }
+    return res;
+  }
+private:
+  std::string hexStr;
 };
 
 // A timestamp is essentially a string using YYMMDDhhmmssX format (where
@@ -241,7 +283,7 @@ DEFINE_FIELD(p1_version_be, std::string_view, ObisId(0, 0, 96, 1, 4), StringFiel
 DEFINE_FIELD(timestamp, std::string_view, ObisId(0, 0, 1, 0, 0), TimestampField);
 
 // Equipment identifier
-DEFINE_FIELD(equipment_id, std::string_view, ObisId(0, 0, 96, 1, 1), StringField, 0, 96);
+DEFINE_FIELD(equipment_id, std::string_view, ObisId(0, 0, 96, 1, 1), HexStringField, 0, 96);
 
 // Meter Reading electricity delivered to client (Special for Lux) in 0,001 kWh
 // TODO: by OBIS 1-0:1.8.0.255 IEC 62056 it should be Positive active energy (A+) total [kWh], should we rename it?
@@ -482,9 +524,9 @@ DEFINE_FIELD(active_demand_abs, FixedValue, ObisId(1, 0, 15, 24, 0), FixedField,
 DEFINE_FIELD(gas_device_type, uint16_t, ObisId(0, DSMR_GAS_MBUS_ID, 24, 1, 0), IntField, units::none);
 
 // Equipment identifier (Gas)
-DEFINE_FIELD(gas_equipment_id, std::string_view, ObisId(0, DSMR_GAS_MBUS_ID, 96, 1, 0), StringField, 0, 96);
+DEFINE_FIELD(gas_equipment_id, std::string_view, ObisId(0, DSMR_GAS_MBUS_ID, 96, 1, 0), HexStringField, 0, 96);
 // Equipment identifier (Gas) BE
-DEFINE_FIELD(gas_equipment_id_be, std::string_view, ObisId(0, DSMR_GAS_MBUS_ID, 96, 1, 1), StringField, 0, 96);
+DEFINE_FIELD(gas_equipment_id_be, std::string_view, ObisId(0, DSMR_GAS_MBUS_ID, 96, 1, 1), HexStringField, 0, 96);
 
 // Valve position Gas (on/off/released) (Note: Removed in 4.0.7 / 4.2.2 / 5.0).
 DEFINE_FIELD(gas_valve_position, uint8_t, ObisId(0, DSMR_GAS_MBUS_ID, 24, 4, 0), IntField, units::none);
@@ -502,7 +544,7 @@ DEFINE_FIELD(gas_delivered_text, std::string_view, ObisId(0, DSMR_GAS_MBUS_ID, 2
 DEFINE_FIELD(thermal_device_type, uint16_t, ObisId(0, DSMR_THERMAL_MBUS_ID, 24, 1, 0), IntField, units::none);
 
 // Equipment identifier (Thermal: heat or cold)
-DEFINE_FIELD(thermal_equipment_id, std::string_view, ObisId(0, DSMR_THERMAL_MBUS_ID, 96, 1, 0), StringField, 0, 96);
+DEFINE_FIELD(thermal_equipment_id, std::string_view, ObisId(0, DSMR_THERMAL_MBUS_ID, 96, 1, 0), HexStringField, 0, 96);
 
 // Valve position (on/off/released) (Note: Removed in 4.0.7 / 4.2.2 / 5.0).
 DEFINE_FIELD(thermal_valve_position, uint8_t, ObisId(0, DSMR_THERMAL_MBUS_ID, 24, 4, 0), IntField, units::none);
@@ -515,7 +557,7 @@ DEFINE_FIELD(thermal_delivered, TimestampedFixedValue, ObisId(0, DSMR_THERMAL_MB
 DEFINE_FIELD(water_device_type, uint16_t, ObisId(0, DSMR_WATER_MBUS_ID, 24, 1, 0), IntField, units::none);
 
 // Equipment identifier (Thermal: heat or cold)
-DEFINE_FIELD(water_equipment_id, std::string_view, ObisId(0, DSMR_WATER_MBUS_ID, 96, 1, 0), StringField, 0, 96);
+DEFINE_FIELD(water_equipment_id, std::string_view, ObisId(0, DSMR_WATER_MBUS_ID, 96, 1, 0), HexStringField, 0, 96);
 
 // Valve position (on/off/released) (Note: Removed in 4.0.7 / 4.2.2 / 5.0).
 DEFINE_FIELD(water_valve_position, uint8_t, ObisId(0, DSMR_WATER_MBUS_ID, 24, 4, 0), IntField, units::none);
@@ -528,7 +570,7 @@ DEFINE_FIELD(water_delivered, TimestampedFixedValue, ObisId(0, DSMR_WATER_MBUS_I
 DEFINE_FIELD(sub_device_type, uint16_t, ObisId(0, DSMR_SUB_MBUS_ID, 24, 1, 0), IntField, units::none);
 
 // Equipment identifier (Thermal: heat or cold)
-DEFINE_FIELD(sub_equipment_id, std::string_view, ObisId(0, DSMR_SUB_MBUS_ID, 96, 1, 0), StringField, 0, 96);
+DEFINE_FIELD(sub_equipment_id, std::string_view, ObisId(0, DSMR_SUB_MBUS_ID, 96, 1, 0), HexStringField, 0, 96);
 
 // Valve position (on/off/released) (Note: Removed in 4.0.7 / 4.2.2 / 5.0).
 DEFINE_FIELD(sub_valve_position, uint8_t, ObisId(0, DSMR_SUB_MBUS_ID, 24, 4, 0), IntField, units::none);

--- a/src/dsmr_parser/fields.h
+++ b/src/dsmr_parser/fields.h
@@ -2,8 +2,9 @@
 
 #include "parser.h"
 #include "util.h"
-#include <optional>
 #include <algorithm>
+#include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 
@@ -42,42 +43,41 @@ struct StringField : ParsedField<T> {
   }
 };
 
-// A hexstring field is essencially a string filled with hex digits. If the
-// string does not consist of an even number of hex digits, the original
-// string is returned, otherwise the decoded hex string is returned.
+// Uses heuristics to detect if a string is hex-encoded or not.
 template <typename T, size_t minlen, size_t maxlen>
-struct HexStringField : ParsedField<T> {
+struct HexStringOrRegularStringField : ParsedField<T> {
   std::optional<std::string_view> parse(std::string_view input) {
     std::string_view sv;
     auto res = parse_string(sv, minlen, maxlen, input);
-    if (res) {
-      static_cast<T*>(this)->val() = sv;
+    if (!res)
+      return std::nullopt;
 
-      if (sv.length() & 1) {
-        // Odd number of chars, can't be a hex coded string.
+    static_cast<T*>(this)->val() = sv;
+
+    auto is_hex_digit = [](char ch) { return (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F'); };
+    auto is_alnum = [](char ch) { return (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z'); };
+
+    // Only an even number of uppercase hex digits can be a hex coded string.
+    if ((sv.length() & 1) || !std::ranges::all_of(sv, is_hex_digit))
+      return res;
+
+    auto value = [](char ch) { return ch <= '9' ? ch - '0' : ch - 'A' + 10; };
+
+    hexStr.clear();
+    hexStr.reserve(sv.length() / 2);
+    for (size_t i = 0; i < sv.length(); i += 2) {
+      const auto ch = static_cast<char>((value(sv[i]) << 4) + value(sv[i + 1]));
+      if (!is_alnum(ch)) {
+        // Decoded byte is not a digit or uppercase letter.
+        hexStr.clear();
         return res;
       }
-      if (!std::all_of(sv.begin(), sv.end(), [](unsigned char ch){ return isxdigit(ch); })) {
-        // Not all chars are hex digits.
-        return res;
-      }
-      hexStr.clear();
-      hexStr.reserve(sv.length()/2);
-      for (auto it = sv.begin(); it != sv.end(); ++it) {
-        const int ch1 = *it++;
-        const int ch2 = *it;
-        auto val = (isdigit(ch1) ? ch1 - '0' : toupper(ch1) - 'A' + 10) * 16 +
-                   (isdigit(ch2) ? ch2 - '0' : toupper(ch2) - 'A' + 10);
-	if (val < 0x20 || val > 0x7E) {
-          // Not visible ascii.
-          return res;
-        }
-        hexStr.push_back(static_cast<char>(val));
-      }
-      static_cast<T*>(this)->val() = std::string_view(hexStr);
+      hexStr.push_back(ch);
     }
+    static_cast<T*>(this)->val() = std::string_view(hexStr);
     return res;
   }
+
 private:
   std::string hexStr;
 };
@@ -283,7 +283,7 @@ DEFINE_FIELD(p1_version_be, std::string_view, ObisId(0, 0, 96, 1, 4), StringFiel
 DEFINE_FIELD(timestamp, std::string_view, ObisId(0, 0, 1, 0, 0), TimestampField);
 
 // Equipment identifier
-DEFINE_FIELD(equipment_id, std::string_view, ObisId(0, 0, 96, 1, 1), HexStringField, 0, 96);
+DEFINE_FIELD(equipment_id, std::string_view, ObisId(0, 0, 96, 1, 1), HexStringOrRegularStringField, 0, 96);
 
 // Meter Reading electricity delivered to client (Special for Lux) in 0,001 kWh
 // TODO: by OBIS 1-0:1.8.0.255 IEC 62056 it should be Positive active energy (A+) total [kWh], should we rename it?
@@ -524,9 +524,9 @@ DEFINE_FIELD(active_demand_abs, FixedValue, ObisId(1, 0, 15, 24, 0), FixedField,
 DEFINE_FIELD(gas_device_type, uint16_t, ObisId(0, DSMR_GAS_MBUS_ID, 24, 1, 0), IntField, units::none);
 
 // Equipment identifier (Gas)
-DEFINE_FIELD(gas_equipment_id, std::string_view, ObisId(0, DSMR_GAS_MBUS_ID, 96, 1, 0), HexStringField, 0, 96);
+DEFINE_FIELD(gas_equipment_id, std::string_view, ObisId(0, DSMR_GAS_MBUS_ID, 96, 1, 0), HexStringOrRegularStringField, 0, 96);
 // Equipment identifier (Gas) BE
-DEFINE_FIELD(gas_equipment_id_be, std::string_view, ObisId(0, DSMR_GAS_MBUS_ID, 96, 1, 1), HexStringField, 0, 96);
+DEFINE_FIELD(gas_equipment_id_be, std::string_view, ObisId(0, DSMR_GAS_MBUS_ID, 96, 1, 1), HexStringOrRegularStringField, 0, 96);
 
 // Valve position Gas (on/off/released) (Note: Removed in 4.0.7 / 4.2.2 / 5.0).
 DEFINE_FIELD(gas_valve_position, uint8_t, ObisId(0, DSMR_GAS_MBUS_ID, 24, 4, 0), IntField, units::none);
@@ -544,7 +544,7 @@ DEFINE_FIELD(gas_delivered_text, std::string_view, ObisId(0, DSMR_GAS_MBUS_ID, 2
 DEFINE_FIELD(thermal_device_type, uint16_t, ObisId(0, DSMR_THERMAL_MBUS_ID, 24, 1, 0), IntField, units::none);
 
 // Equipment identifier (Thermal: heat or cold)
-DEFINE_FIELD(thermal_equipment_id, std::string_view, ObisId(0, DSMR_THERMAL_MBUS_ID, 96, 1, 0), HexStringField, 0, 96);
+DEFINE_FIELD(thermal_equipment_id, std::string_view, ObisId(0, DSMR_THERMAL_MBUS_ID, 96, 1, 0), HexStringOrRegularStringField, 0, 96);
 
 // Valve position (on/off/released) (Note: Removed in 4.0.7 / 4.2.2 / 5.0).
 DEFINE_FIELD(thermal_valve_position, uint8_t, ObisId(0, DSMR_THERMAL_MBUS_ID, 24, 4, 0), IntField, units::none);
@@ -557,7 +557,7 @@ DEFINE_FIELD(thermal_delivered, TimestampedFixedValue, ObisId(0, DSMR_THERMAL_MB
 DEFINE_FIELD(water_device_type, uint16_t, ObisId(0, DSMR_WATER_MBUS_ID, 24, 1, 0), IntField, units::none);
 
 // Equipment identifier (Thermal: heat or cold)
-DEFINE_FIELD(water_equipment_id, std::string_view, ObisId(0, DSMR_WATER_MBUS_ID, 96, 1, 0), HexStringField, 0, 96);
+DEFINE_FIELD(water_equipment_id, std::string_view, ObisId(0, DSMR_WATER_MBUS_ID, 96, 1, 0), HexStringOrRegularStringField, 0, 96);
 
 // Valve position (on/off/released) (Note: Removed in 4.0.7 / 4.2.2 / 5.0).
 DEFINE_FIELD(water_valve_position, uint8_t, ObisId(0, DSMR_WATER_MBUS_ID, 24, 4, 0), IntField, units::none);
@@ -570,7 +570,7 @@ DEFINE_FIELD(water_delivered, TimestampedFixedValue, ObisId(0, DSMR_WATER_MBUS_I
 DEFINE_FIELD(sub_device_type, uint16_t, ObisId(0, DSMR_SUB_MBUS_ID, 24, 1, 0), IntField, units::none);
 
 // Equipment identifier (Thermal: heat or cold)
-DEFINE_FIELD(sub_equipment_id, std::string_view, ObisId(0, DSMR_SUB_MBUS_ID, 96, 1, 0), HexStringField, 0, 96);
+DEFINE_FIELD(sub_equipment_id, std::string_view, ObisId(0, DSMR_SUB_MBUS_ID, 96, 1, 0), HexStringOrRegularStringField, 0, 96);
 
 // Valve position (on/off/released) (Note: Removed in 4.0.7 / 4.2.2 / 5.0).
 DEFINE_FIELD(sub_valve_position, uint8_t, ObisId(0, DSMR_SUB_MBUS_ID, 24, 4, 0), IntField, units::none);

--- a/src/dsmr_parser/fields.h
+++ b/src/dsmr_parser/fields.h
@@ -24,7 +24,7 @@
 namespace dsmr_parser {
 
 template <typename T>
-struct ParsedField {
+struct ParsedField : NonCopyableAndNonMovable {
   template <typename F>
   void apply(F& f) {
     f.apply(*static_cast<T*>(this));

--- a/tests/packet_accumulator_example_test.cpp
+++ b/tests/packet_accumulator_example_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE_FIXTURE(LogFixture, "PacketAccumulator example") {
   for (const char byte : data_from_p1_port) {
     // Feed the byte to the accumulator.
     std::optional<DsmrUnencryptedTelegram> dsmrTelegram = accumulator.process_byte(static_cast<uint8_t>(byte));
-    if(!dsmrTelegram) {
+    if (!dsmrTelegram) {
       // No full packet received yet
       continue;
     }

--- a/tests/packet_accumulator_test.cpp
+++ b/tests/packet_accumulator_test.cpp
@@ -18,7 +18,7 @@ TEST_CASE_FIXTURE(LogFixture, "Packet with correct CRC") {
   std::optional<DsmrUnencryptedTelegram> dsmrTelegram;
   for (const auto& byte : msg) {
     dsmrTelegram = accumulator.process_byte(static_cast<uint8_t>(byte));
-    if(dsmrTelegram)
+    if (dsmrTelegram)
       break;
   }
   REQUIRE(dsmrTelegram);

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -676,6 +676,64 @@ TEST_CASE_FIXTURE(LogFixture, "Should parse hexified equipment_id field") {
   REQUIRE(data.equipment_id == "E0062000014504029");
 }
 
+TEST_CASE_FIXTURE(LogFixture, "Should keep equipment_id as-is when not hex encoded") {
+  const auto& msg = "/identification\r\n"
+                    "0-0:96.1.1(Some long string 32 bytes)\r\n"
+                    "!";
+
+  ParsedData<equipment_id> data;
+
+  const auto& res = DsmrParser::parse(data, *DsmrUnencryptedTelegram::from_bytes(msg, false), /* unknown_error */ true);
+  REQUIRE(res);
+  REQUIRE(data.equipment_id == "Some long string 32 bytes");
+}
+
+TEST_CASE_FIXTURE(LogFixture, "Should keep equipment_id as-is for odd number of hex digits") {
+  // Odd length cannot be hex-decoded, so it is kept verbatim.
+  const auto& msg = "/identification\r\n"
+                    "0-0:96.1.1(45303)\r\n"
+                    "!";
+
+  ParsedData<equipment_id> data;
+  const auto& res = DsmrParser::parse(data, *DsmrUnencryptedTelegram::from_bytes(msg, false), /* unknown_error */ true);
+  REQUIRE(res);
+  REQUIRE(data.equipment_id == "45303");
+}
+
+TEST_CASE_FIXTURE(LogFixture, "Should keep equipment_id as-is when lowercase hex digits are present") {
+  const auto& msg = "/identification\r\n"
+                    "0-0:96.1.1(4530303632303030303134353034303239aa)\r\n"
+                    "!";
+
+  // Lowercase letters are not treated as hex digits, so the value is kept verbatim.
+  ParsedData<equipment_id> data;
+  const auto& res = DsmrParser::parse(data, *DsmrUnencryptedTelegram::from_bytes(msg, false), /* unknown_error */ true);
+  REQUIRE(res);
+  REQUIRE(data.equipment_id == "4530303632303030303134353034303239aa");
+}
+
+TEST_CASE_FIXTURE(LogFixture, "Should keep equipment_id as-is when decoded byte is not alphanumeric") {
+  const auto& msg = "/identification\r\n"
+                    "0-0:96.1.1(00)\r\n" // 0x00 is not a digit or uppercase letter
+                    "!";
+
+  ParsedData<equipment_id> data;
+  const auto& res = DsmrParser::parse(data, *DsmrUnencryptedTelegram::from_bytes(msg, false), /* unknown_error */ true);
+  REQUIRE(res);
+  REQUIRE(data.equipment_id == "00");
+}
+
+TEST_CASE_FIXTURE(LogFixture, "Should parse an empty equipment_id field") {
+  const auto& msg = "/identification\r\n"
+                    "0-0:96.1.1()\r\n"
+                    "!";
+
+  ParsedData<equipment_id> data;
+  const auto& res = DsmrParser::parse(data, *DsmrUnencryptedTelegram::from_bytes(msg, false), /* unknown_error */ true);
+  REQUIRE(res);
+  REQUIRE(data.equipment_id == "");
+}
+
 TEST_CASE_FIXTURE(LogFixture, "Missing opening parenthesis for numeric field") {
   const auto& msg = "/AAA5MTR\r\n"
                     "\r\n"

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -664,6 +664,18 @@ TEST_CASE_FIXTURE(LogFixture, "Should parse gas_delivered_gj field") {
   REQUIRE(data.gas_delivered_gj == 3.829f);
 }
 
+TEST_CASE_FIXTURE(LogFixture, "Should parse hexified equipment_id field") {
+  const auto& msg = "/identification\r\n"
+                    "0-0:96.1.1(4530303632303030303134353034303239)\r\n"
+                    "!";
+
+  ParsedData<equipment_id> data;
+
+  const auto& res = DsmrParser::parse(data, *DsmrUnencryptedTelegram::from_bytes(msg, false), /* unknown_error */ true);
+  REQUIRE(res);
+  REQUIRE(data.equipment_id == "E0062000014504029");
+}
+
 TEST_CASE_FIXTURE(LogFixture, "Missing opening parenthesis for numeric field") {
   const auto& msg = "/AAA5MTR\r\n"
                     "\r\n"

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "dsmr_parser/util.h"
 #include "dsmr_parser/packet_accumulator.h"
+#include "dsmr_parser/util.h"
 #include <cstdio>
 #include <string>
 #include <vector>
@@ -23,7 +23,9 @@ public:
     });
   }
 
-  ~LogCapturer() { dsmr_parser::Logger::set_log_function([](dsmr_parser::LogLevel, const char*, va_list) {}); }
+  ~LogCapturer() {
+    dsmr_parser::Logger::set_log_function([](dsmr_parser::LogLevel, const char*, va_list) {});
+  }
 
   bool contains(const std::string& substr) const {
     for (const auto& msg : messages) {


### PR DESCRIPTION
If the string does not cleanly decode to a hex string the underlaying string is returned instead.

For example my Dutch Sagencom DSMR uses this as DeviceID
  `0-0:96.1.1(4530303639303030373138323035333231)`
which is hex coded ascii and converts to `E0069000718205321` (which matches the id on the front of the unit).

This is a repost of an ancient https://github.com/esphome-libs/dsmr_parser/pull/12, but cleaned up due to recent changes. It has been running great for me in the past years!