### PR TITLE
Fix frequency field: report Hz and accept float-Hz format

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "dsmr_parser",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A parser for Dutch Smart Meter Requirements (DSMR) telegrams. Fork of arduino-dsmr. Doesn't depend on the Arduino framework and has many bug fixes and code quality improvements. Supports encrypted DSMR packets.",
   "keywords": "dsmr",
   "repository": {

--- a/src/dsmr_parser/fields.h
+++ b/src/dsmr_parser/fields.h
@@ -259,7 +259,6 @@ struct units final {
   static inline constexpr char VA[] = "VA";
   static inline constexpr char s[] = "s";
   static inline constexpr char Hz[] = "Hz";
-  static inline constexpr char kHz[] = "kHz";
   static inline constexpr char mHz[] = "mHz";
 };
 

--- a/src/dsmr_parser/fields.h
+++ b/src/dsmr_parser/fields.h
@@ -260,6 +260,7 @@ struct units final {
   static inline constexpr char s[] = "s";
   static inline constexpr char Hz[] = "Hz";
   static inline constexpr char kHz[] = "kHz";
+  static inline constexpr char mHz[] = "mHz";
 };
 
 #define DEFINE_FIELD(fieldname, value_t, obis, field_t, ...)        \
@@ -444,7 +445,7 @@ DEFINE_FIELD(voltage_avg_l3, FixedValue, ObisId(1, 0, 72, 24, 0), FixedField, un
 // Instantaneous voltage (U) [V]
 DEFINE_FIELD(voltage, FixedValue, ObisId(1, 0, 12, 7, 0), FixedField, units::V, units::mV);
 // Frequency [Hz]
-DEFINE_FIELD(frequency, FixedValue, ObisId(1, 0, 14, 7, 0), FixedField, units::kHz, units::Hz);
+DEFINE_FIELD(frequency, FixedValue, ObisId(1, 0, 14, 7, 0), FixedField, units::Hz, units::mHz);
 // Absolute active instantaneous power (|A|) [kW]
 DEFINE_FIELD(abs_power, FixedValue, ObisId(1, 0, 15, 7, 0), FixedField, units::kW, units::W);
 

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -617,12 +617,31 @@ TEST_CASE_FIXTURE(LogFixture, "Whitespace after OBIS ID") {
 TEST_CASE_FIXTURE(LogFixture, "Use integer fallback unit") {
   const auto& msg = "/KMP5 ZABF000000000000\r\n"
                     "0-1:24.2.1(230101120000W)(00012*dm3)\r\n"
-                    "1-0:14.7.0(50*Hz)\r\n"
+                    "1-0:14.7.0(50000*mHz)\r\n"
                     "!";
   ParsedData<gas_delivered, frequency> data;
   DsmrParser::parse(data, *DsmrUnencryptedTelegram::from_bytes(msg, false), /*unknown_error=*/true);
   REQUIRE(data.gas_delivered == 0.012f);
-  REQUIRE(data.frequency == 0.05f);
+  REQUIRE(data.frequency == 50.0f);
+}
+
+TEST_CASE_FIXTURE(LogFixture, "Frequency reported as float Hz") {
+  // Some meters (e.g. Lithuanian ESO) report grid frequency as a float in Hz,
+  // such as "1-0:14.7.0(49.9*Hz)". This must parse to 49.9 Hz, not 0.0499.
+  const auto& msg = "/KMP5 ZABF000000000000\r\n"
+                    "1-0:14.7.0(49.9*Hz)\r\n"
+                    "!";
+  ParsedData<frequency> data;
+  DsmrParser::parse(data, *DsmrUnencryptedTelegram::from_bytes(msg, false), /*unknown_error=*/true);
+  REQUIRE(data.frequency == 49.9f);
+
+  // An integer value with the Hz unit must also parse to 50.0 Hz (not 0.05).
+  const auto& msg2 = "/KMP5 ZABF000000000000\r\n"
+                     "1-0:14.7.0(50*Hz)\r\n"
+                     "!";
+  ParsedData<frequency> data2;
+  DsmrParser::parse(data2, *DsmrUnencryptedTelegram::from_bytes(msg2, false), /*unknown_error=*/true);
+  REQUIRE(data2.frequency == 50.0f);
 }
 
 TEST_CASE_FIXTURE(LogFixture, "AveragedFixedField works properly for a long array") {

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -38,6 +38,7 @@ TEST_CASE_FIXTURE(LogFixture, "Should parse all fields in the DSMR message corre
                     "1-0:32.36.0(00000)\r\n"
                     "0-0:96.13.1()\r\n"
                     "0-0:96.13.0()\r\n"
+                    "1-0:14.7.0(49.9*Hz)\r\n"
                     "1-0:32.7.0(234.0*V)\r\n"
                     "1-0:52.7.0(231.0*V)\r\n"
                     "1-0:72.7.0(231.0*V)\r\n"
@@ -86,6 +87,7 @@ TEST_CASE_FIXTURE(LogFixture, "Should parse all fields in the DSMR message corre
       /* String */ electricity_tariff_il,
       /* FixedValue */ power_delivered,
       /* FixedValue */ power_returned,
+      /* FixedValue */ frequency,
       /* FixedValue */ electricity_threshold,
       /* String */ electricity_switch_position,
       /* uint32_t */ electricity_failures,
@@ -181,6 +183,7 @@ TEST_CASE_FIXTURE(LogFixture, "Should parse all fields in the DSMR message corre
   REQUIRE(data.power_delivered_l3 == 0.0f);
   REQUIRE(data.power_returned_l1 == 0.0f);
   REQUIRE(data.power_returned_l2 == 0.0f);
+  REQUIRE(data.frequency == 49.9f);
   REQUIRE(data.power_returned_l3 == 0.0f);
   REQUIRE(data.gas_device_type == 3);
   REQUIRE(data.gas_equipment_id == "0000000000000000000000000000000000");
@@ -623,25 +626,6 @@ TEST_CASE_FIXTURE(LogFixture, "Use integer fallback unit") {
   DsmrParser::parse(data, *DsmrUnencryptedTelegram::from_bytes(msg, false), /*unknown_error=*/true);
   REQUIRE(data.gas_delivered == 0.012f);
   REQUIRE(data.frequency == 50.0f);
-}
-
-TEST_CASE_FIXTURE(LogFixture, "Frequency reported as float Hz") {
-  // Some meters (e.g. Lithuanian ESO) report grid frequency as a float in Hz,
-  // such as "1-0:14.7.0(49.9*Hz)". This must parse to 49.9 Hz, not 0.0499.
-  const auto& msg = "/KMP5 ZABF000000000000\r\n"
-                    "1-0:14.7.0(49.9*Hz)\r\n"
-                    "!";
-  ParsedData<frequency> data;
-  DsmrParser::parse(data, *DsmrUnencryptedTelegram::from_bytes(msg, false), /*unknown_error=*/true);
-  REQUIRE(data.frequency == 49.9f);
-
-  // An integer value with the Hz unit must also parse to 50.0 Hz (not 0.05).
-  const auto& msg2 = "/KMP5 ZABF000000000000\r\n"
-                     "1-0:14.7.0(50*Hz)\r\n"
-                     "!";
-  ParsedData<frequency> data2;
-  DsmrParser::parse(data2, *DsmrUnencryptedTelegram::from_bytes(msg2, false), /*unknown_error=*/true);
-  REQUIRE(data2.frequency == 50.0f);
 }
 
 TEST_CASE_FIXTURE(LogFixture, "AveragedFixedField works properly for a long array") {


### PR DESCRIPTION
## Problem
The frequency field (`1-0:14.7.0`) is defined `FixedField<units::kHz, units::Hz>`. Since `FixedValue` stores thousandths and `FixedField` parses the float unit at 3 decimals:

1. **Wrong scale:** `50*Hz` is stored as `50` → `.val() == 0.05` (treated as kHz). The existing test even asserted `data.frequency == 0.05f` for `1-0:14.7.0(50*Hz)`.
2. **Parse failure:** a float value in Hz such as `1-0:14.7.0(49.9*Hz)` (sent by Lithuanian **ESO** meters) matches neither `kHz` (float) nor integer `Hz`, so `parse_num` logs `Missing unit` and the **whole telegram is rejected** — every sensor goes unavailable.

No meter reports grid frequency in kHz.

## Fix
Redefine the field as `FixedField<units::Hz, units::mHz>` (and add the `mHz` unit). Now:

| telegram | result |
|---|---|
| `49.9*Hz` | 49.9 Hz |
| `50*Hz` / `50.000*Hz` | 50.0 Hz |
| `50000*mHz` | 50.0 Hz |

## Tests
Updated the integer-fallback case to use `mHz` (now `== 50.0f`) and added a case for float Hz (`49.9*Hz == 49.9f`).